### PR TITLE
 fix: plain text mail miss content-type header

### DIFF
--- a/tardis/src/mail/mail_client.rs
+++ b/tardis/src/mail/mail_client.rs
@@ -82,7 +82,7 @@ impl TardisMailClient {
                     .singlepart(SinglePart::builder().header(header::ContentType::TEXT_HTML).body(html_body.to_string())),
             )?
         } else {
-            email.body(req.txt_body.clone())?
+            email.header(header::ContentType::TEXT_PLAIN).body(req.txt_body.clone())?
         };
         trace!(
             "[Tardis.MailClient] Sending email:{}, from: {}, to: {}",


### PR DESCRIPTION
Email client send plain text mail without content-type header, leading potential garbled Chinese content. 
A content-type header is added to ensure mail client decoded content as utf-8.