### PR TITLE
fix: nacos token expire will lead restart

### DIFF
--- a/tardis/src/config/config_nacos/nacos_client.rs
+++ b/tardis/src/config/config_nacos/nacos_client.rs
@@ -90,14 +90,14 @@ impl NacosClient {
     }
 
     /// create a new nacos client, with unsafe option
-    ///
+    /// # Safety
     /// **⚠ Don't use this in production environment ⚠**
     /// # Panic
     /// panic when reqwest_client build failed
     pub unsafe fn new_test(base_url: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
-            reqwest_client: reqwest::Client::builder().danger_accept_invalid_certs(true).danger_accept_invalid_hostnames(true).build().expect("fail to build test NacosClient"),
+            reqwest_client: reqwest::Client::builder().danger_accept_invalid_certs(true).build().expect("fail to build test NacosClient"),
             ..Default::default()
         }
     }

--- a/tardis/src/config/config_nacos/nacos_client.rs
+++ b/tardis/src/config/config_nacos/nacos_client.rs
@@ -5,6 +5,7 @@ use derive_more::Display;
 use crypto::{digest::Digest, md5::Md5};
 use reqwest::Error as ReqwestError;
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 use tracing::{debug, info};
 
 const ACCESS_TOKEN_FIELD: &str = "accessToken";
@@ -14,8 +15,14 @@ pub enum NacosClientError {
     ReqwestError(ReqwestError),
     IoError(std::io::Error),
     UrlParseError(url::ParseError),
+    NoAuth,
 }
 
+impl From<reqwest::Error> for NacosClientError {
+    fn from(value: reqwest::Error) -> Self {
+        NacosClientError::ReqwestError(value)
+    }
+}
 impl std::error::Error for NacosClientError {}
 
 /// for request nacos openapi, see https://nacos.io/zh-cn/docs/open-api.html
@@ -24,8 +31,9 @@ pub struct NacosClient {
     pub base_url: String,
     /// listener poll period, default 5s
     pub poll_period: std::time::Duration,
-    access_token: Option<String>,
+    access_token: Arc<Mutex<Option<String>>>,
     reqwest_client: reqwest::Client,
+    auth: Option<(String, String)>,
 }
 
 impl Display for NacosClient {
@@ -43,8 +51,9 @@ impl Default for NacosClient {
         Self {
             base_url: "http://localhost:8848/nacos".to_owned(),
             poll_period: std::time::Duration::from_secs(5),
-            access_token: None,
+            access_token: Default::default(),
             reqwest_client: reqwest::Client::new(),
+            auth: None,
         }
     }
 }
@@ -59,8 +68,9 @@ impl NacosClient {
     }
 
     /// take access token as reqwest acceptable query
-    fn access_token_as_query(&self) -> Vec<(&str, &str)> {
-        self.access_token.as_ref().map(|token| (ACCESS_TOKEN_FIELD, token.as_str())).into_iter().collect()
+    async fn access_token_as_query(&self) -> Vec<(String, String)> {
+        let access_token = self.access_token.lock().await;
+        access_token.as_ref().map(|token| (ACCESS_TOKEN_FIELD.into(), token.clone())).into_iter().collect()
     }
 
     /// authenticate with username and password
@@ -70,8 +80,31 @@ impl NacosClient {
         params.insert("username", username);
         params.insert("password", password);
         let access_token = self.reqwest_client.post(&url).form(&params).send().await?.json::<NacosAuthResponse>().await?.access_token;
-        self.access_token = Some(access_token);
+        {
+            *(self.access_token.lock().await) = Some(access_token);
+        }
+        self.auth = Some((username.to_string(), password.to_string()));
         Ok(self)
+    }
+
+    pub async fn relogin(&self) -> Result<&Self, NacosClientError> {
+        if let Some((ref username, ref password)) = self.auth.clone() {
+            debug!("[Tardis.Config] Trying to re-login");
+            // lock while re-login
+            let mut access_token_lock = self.access_token.lock().await;
+            let url = format!("{}/v1/auth/login", self.base_url);
+            let mut params = HashMap::new();
+            params.insert("username", username);
+            params.insert("password", password);
+            let access_token = self.reqwest_client.post(&url).form(&params).send().await?.json::<NacosAuthResponse>().await?.access_token;
+            *access_token_lock = Some(access_token);
+            // release lock
+            drop(access_token_lock);
+            debug!("[Tardis.Config] Success to re-login");
+            Ok(self)
+        } else {
+            Err(NacosClientError::NoAuth)
+        }
     }
 
     /// publish config by a nacos config descriptor and some content implement `Read`
@@ -82,78 +115,77 @@ impl NacosClient {
         let mut content_buf = String::new();
         content.read_to_string(&mut content_buf).map_err(IoError)?;
         params.insert("content", content_buf);
-        let resp = self.reqwest_client.post(&url).query(descriptor).query(&self.access_token_as_query()).form(&params).send().await;
-        debug!("[Tardis.Config] publish_config resp: {:?}", resp);
-        resp.map_err(ReqwestError)?.json::<bool>().await.map_err(ReqwestError)
+        let mut resp = self.reqwest_client.post(&url).query(descriptor).query(&self.access_token_as_query().await).form(&params).send().await?;
+        if resp.status() == reqwest::StatusCode::FORBIDDEN {
+            self.relogin().await?;
+            resp = self.reqwest_client.post(&url).query(descriptor).query(&self.access_token_as_query().await).form(&params).send().await?;
+        }
+        Ok(resp.json::<bool>().await?)
     }
 
     /// get config by a nacos config descriptor
     pub async fn get_config(&self, descriptor: &NacosConfigDescriptor<'_>) -> Result<String, NacosClientError> {
-        use NacosClientError::*;
         let url = format!("{}/v1/cs/configs", self.base_url);
-        let resp = self.reqwest_client.get(&url).query(descriptor).query(&self.access_token_as_query()).send().await;
-        match resp {
-            Ok(resp) => {
-                let resp = resp.error_for_status();
-                match resp {
-                    Ok(resp) => {
-                        let text = resp.text().await.map_err(ReqwestError)?;
-                        descriptor.update_by_content(&text).await;
-                        Ok(text)
-                    }
-                    Err(e) => Err(ReqwestError(e)),
-                }
-            }
-            Err(e) => Err(ReqwestError(e)),
+        let mut resp = self.reqwest_client.get(&url).query(descriptor).query(&self.access_token_as_query().await).send().await?;
+        if resp.status() == reqwest::StatusCode::FORBIDDEN {
+            resp = self.reqwest_client.get(&url).query(descriptor).query(&self.access_token_as_query().await).send().await?;
         }
+        resp = resp.error_for_status()?;
+        let text = resp.text().await?;
+        descriptor.update_by_content(&text).await;
+        Ok(text)
     }
 
     /// delete config by a nacos config descriptor
     pub async fn delete_config(&self, descriptor: &NacosConfigDescriptor<'_>) -> Result<bool, NacosClientError> {
-        use NacosClientError::*;
         let auth_url = format!("{}/v1/cs/configs", self.base_url);
-        self.reqwest_client
-            .delete(&auth_url)
-            .query(descriptor)
-            .query(&self.access_token_as_query())
+        let mut resp = self.reqwest_client.delete(&auth_url).query(descriptor).query(&self.access_token_as_query().await).send().await?;
+        if resp.status() == reqwest::StatusCode::FORBIDDEN {
+            resp = self.reqwest_client.delete(&auth_url).query(descriptor).query(&self.access_token_as_query().await).send().await?
+        }
+
+        Ok(resp.json::<bool>().await?)
+    }
+
+    async fn listen_config_inner<T: Serialize>(&self, params: &T) -> Result<reqwest::Response, NacosClientError> {
+        let resp = self
+            .reqwest_client
+            .post(&format!("{}/v1/cs/configs/listener", self.base_url))
+            // refer: https://nacos.io/zh-cn/docs/open-api.html
+            // doc says it's `pulling` instead of `polling`
+            .header("Long-Pulling-Timeout", self.poll_period.as_millis().to_string())
+            .query(&self.access_token_as_query().await)
+            .query(&params)
             .send()
-            .await
-            .map_err(ReqwestError)?
-            .json::<bool>()
-            .await
-            .map_err(ReqwestError)
+            .await?;
+        Ok(resp)
     }
 
     /// listen config change, if updated, return Ok(true), if not updated, return Ok(false)
     pub async fn listen_config(&self, descriptor: &NacosConfigDescriptor<'_>) -> Result<bool, NacosClientError> {
-        use NacosClientError::*;
         {
             let md5 = descriptor.md5.lock().await;
             if md5.is_none() {
                 return Ok(false);
             }
         }
-        let url = format!("{}/v1/cs/configs/listener", self.base_url);
         let mut params = HashMap::new();
         params.insert("Listening-Configs", descriptor.as_listening_configs().await);
         debug!("[Tardis.Config] listen_config Listening-Configs: {:?}", params.get("Listening-Configs"));
-        let resp = self
-            .reqwest_client
-            .post(&url)
-            // refer: https://nacos.io/zh-cn/docs/open-api.html
-            // doc says it's `pulling` instead of `polling`
-            .header("Long-Pulling-Timeout", self.poll_period.as_millis().to_string())
-            .query(&self.access_token_as_query())
-            .query(&params)
-            .send()
-            .await
-            .map_err(ReqwestError)?;
+
+        let mut resp = self.listen_config_inner(&params).await?;
+
         debug!("[Tardis.Config] listen_config resp: {:?}", resp);
-        let result = resp.text().await.map_err(ReqwestError)?;
+        // case of token expired
+        if resp.status() == reqwest::StatusCode::FORBIDDEN {
+            self.relogin().await?;
+            resp = self.listen_config_inner(&params).await?;
+        };
+        let result = resp.text().await?;
         let result = if result.is_empty() { None } else { Some(result) };
         if let Some(config_text) = &result {
             {
-                info!("[Tardis.Config] Listening-Configs {} updated", config_text);
+                info!("[Tardis.Config] md5 {} updated", config_text);
                 Ok(true)
             }
         } else {

--- a/tardis/src/config/config_nacos/nacos_client.rs
+++ b/tardis/src/config/config_nacos/nacos_client.rs
@@ -185,7 +185,7 @@ impl NacosClient {
         let result = if result.is_empty() { None } else { Some(result) };
         if let Some(config_text) = &result {
             {
-                info!("[Tardis.Config] md5 {} updated", config_text);
+                debug!("[Tardis.Config] update with digest {}", config_text);
                 Ok(true)
             }
         } else {

--- a/tardis/src/test/test_container/nacos_server.rs
+++ b/tardis/src/test/test_container/nacos_server.rs
@@ -51,7 +51,8 @@ def_container! {
         mode:                       NacosServerMode = NacosServerMode::Cluster,
         nacos_auth_identity_key:    String          = "nacos",
         nacos_auth_identity_value:  String          = "nacos",
-        nacos_auth_token:           String          = "TARDIS-NACOS-SERVER-TEST-CONTAINER"
+        nacos_auth_token:           String          = "TARDIS-NACOS-SERVER-TEST-CONTAINER",
+        nacos_auth_token_expire_seconds:    usize   = 18000_usize
     }
 }
 

--- a/tardis/tests/test_config_with_remote.rs
+++ b/tardis/tests/test_config_with_remote.rs
@@ -97,7 +97,7 @@ async fn test_config_with_remote() -> TardisResult<()> {
     TardisFuns::shutdown().await?;
 
     // load remote config
-    let mut client: NacosClient = NacosClient::new(&docker_env.nacos_url);
+    let mut client: NacosClient = unsafe { NacosClient::new_test(&docker_env.nacos_url) };
     // get auth
     client.login("nacos", "nacos").await?;
     // going to put test-app-default into remote

--- a/tardis/tests/test_config_with_remote.rs
+++ b/tardis/tests/test_config_with_remote.rs
@@ -56,6 +56,7 @@ fn initialize_docker_env(cli: &Cli) -> DockerEnv {
         .nacos_auth_identity_key("nacos".into())
         .nacos_auth_identity_value("nacos".into())
         .nacos_auth_token(tardis::crypto::crypto_base64::TardisCryptoBase64.encode("nacos server for test_config_with_remote"))
+        .nacos_auth_token_expire_seconds(10)
         .mode(NacosServerMode::Standalone);
     nacos.tag = "v2.1.1-slim".to_string();
     let nacos = cli.run(nacos);
@@ -84,7 +85,7 @@ fn initialize_docker_env(cli: &Cli) -> DockerEnv {
 
 #[tokio::test]
 async fn test_config_with_remote() -> TardisResult<()> {
-    env::set_var("RUST_LOG", "info,tardis=debug");
+    env::set_var("RUST_LOG", "info,tardis::config=debug");
     env::set_var("PROFILE", "remote");
 
     let docker = testcontainers::clients::Cli::docker();
@@ -156,7 +157,7 @@ async fn test_config_with_remote() -> TardisResult<()> {
     let update_result = client.publish_config(&remote_cfg_default, &mut config_file.as_bytes()).await.expect("fail to update remote config");
     info!("update remote config result: {:?}", update_result);
     // 4.1 wait for polling, and tardis will reboot since the remote config has been updated
-    let mut count_down = 15;
+    let mut count_down = 30;
     while count_down > 0 {
         if count_down % 5 == 0 {
             info!("wait {}s for polling", count_down);


### PR DESCRIPTION
Fix：
Nacos token expire will lead service restart
Now, if got a response with status 403, nacos client will try to re-login. 