### PR TITLE
Feat optional middleware

### DIFF
--- a/tardis/src/config/config_dto.rs
+++ b/tardis/src/config/config_dto.rs
@@ -257,7 +257,7 @@ pub struct WebServerConfig {
     /// ``OpenAPI`` information path / ``OpenAPI`` 信息路径
     pub spec_path: Option<String>,
     /// Enable `UniformError` middleware / 启用 `UniformError` 中间件
-    /// 
+    ///
     /// It's enabled by default. In some case like running a mocker server, it may be supposed to be closed
     pub uniform_error: bool,
     /// Web module configuration / Web模块配置
@@ -332,7 +332,7 @@ pub struct WebServerModuleConfig {
     /// Module ``OpenAPI`` information path / 模块 ``OpenAPI`` 信息路径
     pub spec_path: Option<String>,
     /// Enable `UniformError` middleware / 启用 `UniformError` 中间件
-    /// 
+    ///
     /// It's enabled by default. In some case like running a mocker server, it may be supposed to be closed
     pub uniform_error: bool,
 }
@@ -376,7 +376,7 @@ impl Default for WebServerModuleConfig {
             req_headers: vec![],
             ui_path: Some("ui".to_string()),
             spec_path: Some("spec".to_string()),
-            uniform_error: true
+            uniform_error: true,
         }
     }
 }

--- a/tardis/src/config/config_dto.rs
+++ b/tardis/src/config/config_dto.rs
@@ -256,6 +256,10 @@ pub struct WebServerConfig {
     pub ui_path: Option<String>,
     /// ``OpenAPI`` information path / ``OpenAPI`` 信息路径
     pub spec_path: Option<String>,
+    /// Enable `UniformError` middleware / 启用 `UniformError` 中间件
+    /// 
+    /// It's enabled by default. In some case like running a mocker server, it may be supposed to be closed
+    pub uniform_error: bool,
     /// Web module configuration / Web模块配置
     pub modules: HashMap<String, WebServerModuleConfig>,
 }
@@ -327,6 +331,10 @@ pub struct WebServerModuleConfig {
     pub ui_path: Option<String>,
     /// Module ``OpenAPI`` information path / 模块 ``OpenAPI`` 信息路径
     pub spec_path: Option<String>,
+    /// Enable `UniformError` middleware / 启用 `UniformError` 中间件
+    /// 
+    /// It's enabled by default. In some case like running a mocker server, it may be supposed to be closed
+    pub uniform_error: bool,
 }
 
 impl Default for WebServerContextConfig {
@@ -354,6 +362,7 @@ impl Default for WebServerConfig {
             ui_path: Some("ui".to_string()),
             spec_path: Some("spec".to_string()),
             modules: Default::default(),
+            uniform_error: true,
         }
     }
 }
@@ -367,6 +376,7 @@ impl Default for WebServerModuleConfig {
             req_headers: vec![],
             ui_path: Some("ui".to_string()),
             spec_path: Some("spec".to_string()),
+            uniform_error: true
         }
     }
 }

--- a/tardis/src/web/web_server.rs
+++ b/tardis/src/web/web_server.rs
@@ -71,7 +71,7 @@ impl TardisWebServer {
             req_headers: self.config.req_headers.clone(),
             ui_path: self.config.ui_path.clone(),
             spec_path: self.config.spec_path.clone(),
-            uniform_error: self.config.uniform_error
+            uniform_error: self.config.uniform_error,
         };
         self.do_add_module_with_data("", &module, apis, data, middlewares).await
     }

--- a/tardis/src/web/web_server.rs
+++ b/tardis/src/web/web_server.rs
@@ -71,6 +71,7 @@ impl TardisWebServer {
             req_headers: self.config.req_headers.clone(),
             ui_path: self.config.ui_path.clone(),
             spec_path: self.config.spec_path.clone(),
+            uniform_error: self.config.uniform_error
         };
         self.do_add_module_with_data("", &module, apis, data, middlewares).await
     }
@@ -142,7 +143,10 @@ impl TardisWebServer {
         for middleware in middlewares {
             route = middleware.transform(route);
         }
-        let route = route.with(UniformError).with(cors);
+        if module.uniform_error {
+            route = Box::new(UniformError.transform(route));
+        }
+        let route = route.with(cors);
         // Solved:  Cannot move out of *** which is behind a mutable reference
         // https://stackoverflow.com/questions/63353762/cannot-move-out-of-which-is-behind-a-mutable-reference
         let mut swap_route = Route::new();


### PR DESCRIPTION
Allowing web-server to add a module with middleware `UniformError` disabled
With config
```toml
[web-server.some-module]
# default by true
uniform_error = false 
```
