### PR TITLE
Fix webserver can't restart properly

### DIFF
--- a/examples/multi-apps/doc/src/api/doc_api.rs
+++ b/examples/multi-apps/doc/src/api/doc_api.rs
@@ -6,7 +6,7 @@ use tardis::TardisFuns;
 
 use crate::dto::doc_dto::DocAddReq;
 use crate::serv::doc_serv::DocServ;
-
+#[derive(Debug, Clone)]
 pub struct DocApi;
 
 #[poem_openapi::OpenApi(prefix_path = "/doc")]

--- a/examples/multi-apps/doc/src/initializer.rs
+++ b/examples/multi-apps/doc/src/initializer.rs
@@ -1,5 +1,5 @@
 use tardis::basic::result::TardisResult;
-use tardis::web::web_server::{TardisWebServer, EMPTY_MW};
+use tardis::web::web_server::{TardisWebServer};
 use tardis::TardisFuns;
 
 use crate::api::doc_api;
@@ -7,6 +7,6 @@ use crate::domain::doc;
 
 pub async fn init(web_server: &TardisWebServer) -> TardisResult<()> {
     TardisFuns::reldb().conn().create_table_from_entity(doc::Entity).await?;
-    web_server.add_module("doc", doc_api::DocApi, EMPTY_MW).await;
+    web_server.add_module("doc", doc_api::DocApi).await;
     Ok(())
 }

--- a/examples/multi-apps/doc/src/initializer.rs
+++ b/examples/multi-apps/doc/src/initializer.rs
@@ -1,5 +1,5 @@
 use tardis::basic::result::TardisResult;
-use tardis::web::web_server::{TardisWebServer};
+use tardis::web::web_server::TardisWebServer;
 use tardis::TardisFuns;
 
 use crate::api::doc_api;

--- a/examples/multi-apps/doc/src/initializer.rs
+++ b/examples/multi-apps/doc/src/initializer.rs
@@ -1,5 +1,5 @@
 use tardis::basic::result::TardisResult;
-use tardis::web::web_server::TardisWebServer;
+use tardis::web::web_server::{TardisWebServer, EMPTY_MW};
 use tardis::TardisFuns;
 
 use crate::api::doc_api;
@@ -7,6 +7,6 @@ use crate::domain::doc;
 
 pub async fn init(web_server: &TardisWebServer) -> TardisResult<()> {
     TardisFuns::reldb().conn().create_table_from_entity(doc::Entity).await?;
-    web_server.add_module("doc", doc_api::DocApi, None).await;
+    web_server.add_module("doc", doc_api::DocApi, EMPTY_MW).await;
     Ok(())
 }

--- a/examples/multi-apps/src/main.rs
+++ b/examples/multi-apps/src/main.rs
@@ -39,5 +39,7 @@ async fn main() -> TardisResult<()> {
     TardisFuns::init(Some("config")).await?;
     let web_server = TardisFuns::web_server();
     initializer::init(web_server).await?;
-    web_server.start().await
+    web_server.start().await?;
+    web_server.await;
+    Ok(())
 }

--- a/examples/multi-apps/tag/src/api/tag_api.rs
+++ b/examples/multi-apps/tag/src/api/tag_api.rs
@@ -5,7 +5,7 @@ use tardis::web::poem_openapi;
 use tardis::web::poem_openapi::payload::Json;
 use tardis::web::web_resp::{TardisApiResult, TardisResp};
 use tardis::TardisFuns;
-
+#[derive(Debug, Clone)]
 pub struct TagApi;
 
 #[poem_openapi::OpenApi(prefix_path = "/tag")]

--- a/examples/multi-apps/tag/src/initializer.rs
+++ b/examples/multi-apps/tag/src/initializer.rs
@@ -1,5 +1,5 @@
 use tardis::basic::result::TardisResult;
-use tardis::web::web_server::TardisWebServer;
+use tardis::web::web_server::{TardisWebServer, EMPTY_MW};
 use tardis::TardisFuns;
 
 use crate::api::tag_api::{self};
@@ -7,6 +7,6 @@ use crate::domain::tag;
 
 pub async fn init(web_server: &TardisWebServer) -> TardisResult<()> {
     TardisFuns::reldb().conn().create_table_from_entity(tag::Entity).await?;
-    web_server.add_module("tag", tag_api::TagApi, None).await;
+    web_server.add_module("tag", tag_api::TagApi, EMPTY_MW).await;
     Ok(())
 }

--- a/examples/multi-apps/tag/src/initializer.rs
+++ b/examples/multi-apps/tag/src/initializer.rs
@@ -1,5 +1,5 @@
 use tardis::basic::result::TardisResult;
-use tardis::web::web_server::{TardisWebServer, EMPTY_MW};
+use tardis::web::web_server::{TardisWebServer};
 use tardis::TardisFuns;
 
 use crate::api::tag_api::{self};
@@ -7,6 +7,6 @@ use crate::domain::tag;
 
 pub async fn init(web_server: &TardisWebServer) -> TardisResult<()> {
     TardisFuns::reldb().conn().create_table_from_entity(tag::Entity).await?;
-    web_server.add_module("tag", tag_api::TagApi, EMPTY_MW).await;
+    web_server.add_module("tag", tag_api::TagApi).await;
     Ok(())
 }

--- a/examples/multi-apps/tag/src/initializer.rs
+++ b/examples/multi-apps/tag/src/initializer.rs
@@ -1,5 +1,5 @@
 use tardis::basic::result::TardisResult;
-use tardis::web::web_server::{TardisWebServer};
+use tardis::web::web_server::TardisWebServer;
 use tardis::TardisFuns;
 
 use crate::api::tag_api::{self};

--- a/examples/perf-test/src/main.rs
+++ b/examples/perf-test/src/main.rs
@@ -20,5 +20,7 @@ async fn main() -> TardisResult<()> {
     TardisFuns::init(Some("config")).await?;
     initializer::init().await?;
     // Register the processor and start the web service
-    TardisFuns::web_server().add_route(TodoApi).await.start().await
+    TardisFuns::web_server().add_route(TodoApi).await.start().await?;
+    TardisFuns::web_server().await;
+    Ok(())
 }

--- a/examples/perf-test/src/processor.rs
+++ b/examples/perf-test/src/processor.rs
@@ -35,6 +35,7 @@ struct TodoModifyReq {
     done: Option<bool>,
 }
 
+#[derive(Debug, Clone)]
 pub struct TodoApi;
 
 #[poem_openapi::OpenApi]

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -30,5 +30,7 @@ async fn main() -> TardisResult<()> {
     TardisFuns::init(Some("config")).await?;
     initializer::init().await?;
     // Register the processor and start the web service
-    TardisFuns::web_server().add_route(TodoApi).await.start().await
+    TardisFuns::web_server().add_route(TodoApi).await.start().await?;
+    TardisFuns::web_server().await;
+    Ok(())
 }

--- a/examples/todos/src/processor.rs
+++ b/examples/todos/src/processor.rs
@@ -39,6 +39,7 @@ struct TodoModifyReq {
     done: Option<bool>,
 }
 
+#[derive(Debug, Clone)]
 pub struct TodoApi;
 
 #[poem_openapi::OpenApi(prefix_path = "/todo")]

--- a/examples/tracing-otlp/src/main.rs
+++ b/examples/tracing-otlp/src/main.rs
@@ -19,5 +19,7 @@ async fn main() -> TardisResult<()> {
     // Initial configuration
     TardisFuns::init(Some("config")).await?;
     // Register the processor and start the web service
-    TardisFuns::web_server().add_route(Api).await.start().await
+    TardisFuns::web_server().add_route(Api).await.start().await;
+    web_server.await;
+    Ok(())
 }

--- a/examples/web-basic/src/main.rs
+++ b/examples/web-basic/src/main.rs
@@ -18,5 +18,7 @@ async fn main() -> TardisResult<()> {
     // Initial configuration
     TardisFuns::init(Some("config")).await?;
     // Register the processor and start the web service
-    TardisFuns::web_server().add_route(Api).await.start().await
+    TardisFuns::web_server().add_route(Api).await.start().await?;
+    TardisFuns::web_server().await;
+    Ok(())
 }

--- a/examples/web-basic/src/processor.rs
+++ b/examples/web-basic/src/processor.rs
@@ -2,7 +2,7 @@ use tardis::basic::error::TardisError;
 use tardis::web::poem_openapi;
 use tardis::web::poem_openapi::param::Query;
 use tardis::web::web_resp::{TardisApiResult, TardisResp};
-
+#[derive(Debug, Clone, Copy)]
 pub struct Api;
 
 #[poem_openapi::OpenApi]

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -2,8 +2,8 @@ use std::env;
 
 use tardis::basic::result::TardisResult;
 use tardis::tokio;
-use tardis::TardisFuns;
 use tardis::web::web_server::WebServerModule;
+use tardis::TardisFuns;
 
 use crate::processor::Page;
 
@@ -20,5 +20,7 @@ async fn main() -> TardisResult<()> {
     // Initial configuration
     TardisFuns::init(Some("config")).await?;
 
-    TardisFuns::web_server().add_route(WebServerModule::from(Page).with_ws(100)).await.start().await
+    TardisFuns::web_server().add_route(WebServerModule::from(Page).with_ws(100)).await.start().await?;
+    TardisFuns::web_server().await;
+    Ok(())
 }

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -3,6 +3,7 @@ use std::env;
 use tardis::basic::result::TardisResult;
 use tardis::tokio;
 use tardis::TardisFuns;
+use tardis::web::web_server::WebServerModule;
 
 use crate::processor::Page;
 
@@ -19,5 +20,5 @@ async fn main() -> TardisResult<()> {
     // Initial configuration
     TardisFuns::init(Some("config")).await?;
 
-    TardisFuns::web_server().add_route_with_ws(Page, 100).await.start().await
+    TardisFuns::web_server().add_route(WebServerModule::from(Page).with_ws(100)).await.start().await
 }

--- a/examples/websocket/src/processor.rs
+++ b/examples/websocket/src/processor.rs
@@ -9,7 +9,7 @@ use tardis::web::poem_openapi::payload::Html;
 use tardis::web::poem_openapi::{self};
 use tardis::web::ws_processor::{ws_broadcast, ws_echo, TardisWebsocketResp};
 use tardis::TardisFuns;
-
+#[derive(Debug, Clone)]
 pub struct Page;
 
 #[poem_openapi::OpenApi]

--- a/tardis/README.md
+++ b/tardis/README.md
@@ -107,7 +107,9 @@ async fn main() -> TardisResult<()> {
     // Initial configuration
     TardisFuns::init("config").await?;
     // Register the processor and start the web service
-    TardisFuns::web_server().add_module("", Api).start().await
+    TardisFuns::web_server().add_module("", Api).start().await;
+    TardisFuns::web_server().web_server.await;
+    Ok(())
 }
 ```
 

--- a/tardis/src/basic/tracing.rs
+++ b/tardis/src/basic/tracing.rs
@@ -57,11 +57,11 @@ impl TardisTracing {
     }
 
     #[cfg(feature = "tracing")]
-    pub(crate) fn init_tracing(conf: &crate::config::config_dto::TardisConfig) -> TardisResult<()> {
+    pub(crate) fn init_tracing(conf: &crate::config::config_dto::FrameworkConfig) -> TardisResult<()> {
         if INITIALIZED.swap(true, Ordering::SeqCst) {
             return Ok(());
         }
-        if let Some(tracing_config) = conf.fw.log.as_ref() {
+        if let Some(tracing_config) = conf.log.as_ref() {
             if std::env::var_os("RUST_LOG").is_none() {
                 std::env::set_var("RUST_LOG", tracing_config.level.as_str());
             }

--- a/tardis/src/config/config_dto.rs
+++ b/tardis/src/config/config_dto.rs
@@ -771,7 +771,7 @@ impl Default for ConfCenterConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct LogConfig {
     pub level: String,

--- a/tardis/src/config/config_dto.rs
+++ b/tardis/src/config/config_dto.rs
@@ -125,7 +125,7 @@ impl Default for AppConfig {
 ///    ..Default::default()
 /// };
 /// ```
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct DBConfig {
     /// Whether to enable the database operation function / 是否启用数据库操作功能
@@ -146,7 +146,7 @@ pub struct DBConfig {
     pub compatible_type: CompatibleType,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct DBModuleConfig {
     /// Database access Url, Url with permission information / 数据库访问Url，Url带权限信息
@@ -191,7 +191,7 @@ impl Default for DBModuleConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum CompatibleType {
     None,
     Oracle,
@@ -225,7 +225,7 @@ pub enum CompatibleType {
 ///    ..Default::default()
 ///};
 /// ```
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct WebServerConfig {
     /// Whether to enable the web service operation function / 是否启用Web服务操作功能
@@ -275,7 +275,7 @@ pub struct WebServerConfig {
 /// and if it is not specified or has no value it will try to get it from the cache.
 ///
 /// 首先会尝试从请求头信息中获取 [context_header_name](Self::context_header_name) ,如果没指定或是没有值时会尝试从缓存中获取.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct WebServerContextConfig {
     /// Tardis context identifier, used to specify the request header name, default is `Tardis-Context`
@@ -308,7 +308,7 @@ pub struct WebServerContextConfig {
 ///     ..Default::default()
 /// };
 /// ```
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct WebServerModuleConfig {
     /// Module name for ``OpenAPI`` / 模块名称，用于 ``OpenAPI``
@@ -477,7 +477,7 @@ impl Default for CacheModuleConfig {
 ///    ..Default::default()
 ///};
 /// ```
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct MQConfig {
     /// Whether to enable the message queue operation function / 是否启用消息队列操作功能
@@ -488,7 +488,7 @@ pub struct MQConfig {
     pub modules: HashMap<String, MQModuleConfig>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct MQModuleConfig {
     /// Message queue access Url, Url with permission information / 消息队列访问Url，Url带权限信息
@@ -729,18 +729,12 @@ impl ConfCenterConfig {
                 }
             };
             if let Ok(config) = TardisConfig::init(relative_path.as_deref()).await {
-                match TardisFuns::shutdown_inherit().await {
-                    Ok(_) => {}
+                match TardisFuns::hot_reload(config).await {
+                    Ok(_) => {
+                        tracing::info!("[Tardis.config] Tardis hot reloaded");
+                    }
                     Err(e) => {
                         tracing::error!("[Tardis.config] Tardis shutdown with error {}", e);
-                    }
-                }
-                match TardisFuns::init_conf(config).await {
-                    Ok(_) => {
-                        tracing::info!("[Tardis.config] Configuration update succeeded");
-                    }
-                    Err(e) => {
-                        tracing::error!("[Tardis.config] Configuration update failed: {}", e);
                     }
                 }
             } else {

--- a/tardis/src/config/config_dto.rs
+++ b/tardis/src/config/config_dto.rs
@@ -729,7 +729,7 @@ impl ConfCenterConfig {
                 }
             };
             if let Ok(config) = TardisConfig::init(relative_path.as_deref()).await {
-                match TardisFuns::shutdown().await {
+                match TardisFuns::shutdown_inherit().await {
                     Ok(_) => {}
                     Err(e) => {
                         tracing::error!("[Tardis.config] Tardis shutdown with error {}", e);

--- a/tardis/src/config/config_nacos.rs
+++ b/tardis/src/config/config_nacos.rs
@@ -94,7 +94,7 @@ where
                         }
                         Err(e) => {
                             // if receiver dropped, stop watching, since tardis wont be reboot anyway
-                            debug!("[Tardis.config] Nacos Remote config updated, but no receiver found, stop watching, error: {e}");
+                            warn!("[Tardis.config] Nacos Remote config updated, but no receiver found, stop watching, error: {e}");
                         }
                     }
                     break;

--- a/tardis/src/config/config_nacos/nacos_client.rs
+++ b/tardis/src/config/config_nacos/nacos_client.rs
@@ -89,7 +89,7 @@ impl NacosClient {
         }
     }
 
-    #[cfg(feature="test")]
+    #[cfg(feature = "test")]
     /// create a new nacos client, with unsafe option
     /// # Safety
     /// **⚠ Don't use this in production environment ⚠**

--- a/tardis/src/config/config_nacos/nacos_client.rs
+++ b/tardis/src/config/config_nacos/nacos_client.rs
@@ -89,6 +89,7 @@ impl NacosClient {
         }
     }
 
+    #[cfg(feature="test")]
     /// create a new nacos client, with unsafe option
     /// # Safety
     /// **⚠ Don't use this in production environment ⚠**

--- a/tardis/src/lib.rs
+++ b/tardis/src/lib.rs
@@ -1184,6 +1184,7 @@ impl TardisFuns {
 
     /// hot reload tardis instance
     pub async fn hot_reload(conf: TardisConfig) -> TardisResult<()> {
+        #[allow(unused_variables)]
         let old_config = unsafe {
             let cs = replace(&mut TARDIS_INST.custom_config, Some(conf.cs)).expect("hot reload before tardis initialized");
             replace(&mut TARDIS_INST._custom_config_cached, Some(HashMap::new()));

--- a/tardis/src/lib.rs
+++ b/tardis/src/lib.rs
@@ -1167,7 +1167,7 @@ impl TardisFuns {
                 });
             }
         }
-        
+
         while let Some(join_result) = set.join_next().await {
             if let Err(e) = join_result {
                 tracing::error!("[Tardis] Fail to join async shutdown task: {}", e);
@@ -1202,24 +1202,21 @@ impl TardisFuns {
     }
 
     /// shutdown with inherit mode
-    /// 
+    ///
     /// this shutdown function will retain some user setted configs like webserver moudules for next init
     pub async fn shutdown_inherit() -> TardisResult<()> {
         Self::shutdown_internal(false).await
     }
 
     /// hot reload tardis instance
-    pub async fn hot_reload(conf: TardisConfig) -> TardisResult<()>{
+    pub async fn hot_reload(conf: TardisConfig) -> TardisResult<()> {
         let old_config = unsafe {
             let cs = replace(&mut TARDIS_INST.custom_config, Some(conf.cs)).expect("hot reload before tardis initialized");
             replace(&mut TARDIS_INST._custom_config_cached, Some(HashMap::new()));
             let fw = replace(&mut TARDIS_INST.framework_config, Some(conf.fw)).expect("hot reload before tardis initialized");
-            TardisConfig {
-                cs,
-                fw,
-            }
+            TardisConfig { cs, fw }
         };
-        
+
         let fw_config = TardisFuns::fw_config();
 
         #[cfg(feature = "tracing")]

--- a/tardis/src/lib.rs
+++ b/tardis/src/lib.rs
@@ -1116,7 +1116,7 @@ impl TardisFuns {
 
     /// # Parameters
     /// - `clean: bool`: if use clean mode, it will cleanup all user setted configs like webserver modules
-    async fn shutdown_internal(clean: bool) -> TardisResult<()> {
+    async fn shutdown_internal(#[allow(unused_variables)] clean: bool) -> TardisResult<()> {
         tracing::info!("[Tardis] Shutdown...");
         // using a join set to collect async task, because `&TARDIS_INST` is not `Send`
         #[cfg(feature = "web-client")]

--- a/tardis/src/test/test_container.rs
+++ b/tardis/src/test/test_container.rs
@@ -149,7 +149,7 @@ impl TardisTestContainer {
 
     pub fn es_custom(docker: &Cli) -> Container<GenericImage> {
         docker.run(
-            images::generic::GenericImage::new("elasticsearch", "8.1.0")
+            images::generic::GenericImage::new("elasticsearch", "8.7.1")
                 .with_env_var("ELASTIC_PASSWORD", "123456")
                 .with_env_var("discovery.type", "single-node")
                 .with_env_var("ES_JAVA_OPTS", "-Xms512m -Xmx512m")

--- a/tardis/src/web/web_server.rs
+++ b/tardis/src/web/web_server.rs
@@ -130,7 +130,7 @@ impl TardisWebServer {
 
     /// add route
     /// # Usage
-    /// ```no_run
+    /// ```ignore
     /// // add an api
     /// webserver.add_route(api).await;
     /// // add with middleware

--- a/tardis/src/web/web_server.rs
+++ b/tardis/src/web/web_server.rs
@@ -1,3 +1,8 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use async_trait::async_trait;
 use futures_util::lock::Mutex;
 use poem::endpoint::BoxEndpoint;
 use poem::listener::{Listener, RustlsCertificate, RustlsConfig, TcpListener};
@@ -19,7 +24,83 @@ pub struct TardisWebServer {
     app_name: String,
     version: String,
     config: WebServerConfig,
+    initializers: Mutex<Vec<Box<dyn Initializer + Send>>>,
     route: Mutex<Route>,
+}
+
+#[async_trait::async_trait]
+trait Initializer {
+    async fn init(&self, target: &TardisWebServer);
+}
+
+#[derive(Clone)]
+pub struct WebServerModule<T, MW = EmptyMiddleWare, D = String> {
+    apis: T,
+    data: Option<D>,
+    middleware: MW,
+}
+
+#[async_trait::async_trait]
+impl<T, MW, D> Initializer for (String, WebServerModule<T, MW, D>)
+where
+    T: Clone + OpenApi + 'static + Send + Sync ,
+    MW: Clone + Middleware<BoxEndpoint<'static>> + 'static + Send + Sync ,
+    D: Clone + Send + Sync + 'static,
+{
+    async fn init(&self, target: &TardisWebServer) {
+        let (code, ref module) = self;
+        let module_config = target.config.modules.get(code).unwrap_or_else(|| panic!("[Tardis.WebServer] Module {code} not found")).clone();
+        target.do_add_module_with_data(code, &module_config, module.clone()).await;
+    }
+}
+
+impl<T> WebServerModule<T> {
+    pub fn new(apis: T) -> Self {
+        Self {
+            apis,
+            data: None,
+            middleware: EMPTY_MW,
+        }
+    }
+}
+
+impl<T, _MW, _D> WebServerModule<T, _MW, _D> {
+    pub fn data<D>(self, data: D) -> WebServerModule<T, _MW, D> {
+        WebServerModule {
+            apis: self.apis,
+            data: Some(data),
+            middleware: self.middleware,
+        }
+    }
+    pub fn middleware<MW>(self, middleware: MW) -> WebServerModule<T, MW, _D> {
+        WebServerModule {
+            apis: self.apis,
+            data: self.data,
+            middleware,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct EmptyMiddleWare;
+pub const EMPTY_MW: EmptyMiddleWare = EmptyMiddleWare;
+
+impl Middleware<BoxEndpoint<'static>> for EmptyMiddleWare {
+    type Output = BoxEndpoint<'static>;
+
+    fn transform(&self, ep: BoxEndpoint<'static>) -> Self::Output {
+        struct EmptyMiddleWareImpl<E>(E);
+
+        #[async_trait::async_trait]
+        impl<E: poem::Endpoint> poem::Endpoint for EmptyMiddleWareImpl<E> {
+            type Output = poem::Response;
+
+            async fn call(&self, req: poem::Request) -> poem::Result<Self::Output> {
+                self.0.call(req).await.map(poem::IntoResponse::into_response)
+            }
+        }
+        Box::new(EmptyMiddleWareImpl(ep))
+    }
 }
 
 impl TardisWebServer {
@@ -28,7 +109,8 @@ impl TardisWebServer {
             app_name: conf.app.name.clone(),
             version: conf.app.version.clone(),
             config: conf.web_server.clone(),
-            route: Mutex::new(Route::new()),
+            route: Mutex::default(),
+            initializers: Mutex::new(Vec::new()),
         })
     }
 
@@ -41,7 +123,8 @@ impl TardisWebServer {
                 port,
                 ..Default::default()
             },
-            route: Mutex::new(Route::new()),
+            route: Mutex::default(),
+            initializers: Mutex::new(Vec::new()),
         })
     }
 
@@ -49,20 +132,22 @@ impl TardisWebServer {
     where
         T: OpenApi + 'static,
     {
-        self.add_route_with_data::<_, String>(apis, None, None).await
+        self.add_route_with_data::<_, String, EmptyMiddleWare>(apis, None, None).await
     }
 
     pub async fn add_route_with_ws<T>(&self, apis: T, capacity: usize) -> &Self
     where
         T: OpenApi + 'static,
     {
-        self.add_route_with_data::<_, tokio::sync::broadcast::Sender<std::string::String>>(apis, Some(tokio::sync::broadcast::channel::<String>(capacity).0), None).await
+        self.add_route_with_data::<_, tokio::sync::broadcast::Sender<std::string::String>, EmptyMiddleWare>(apis, Some(tokio::sync::broadcast::channel::<String>(capacity).0), None)
+            .await
     }
 
-    pub async fn add_route_with_data<T, D>(&self, apis: T, data: Option<D>, middlewares: impl IntoIterator<Item = BoxMiddleware<'static>>) -> &Self
+    pub async fn add_route_with_data<T, D, MW>(&self, apis: T, data: Option<D>, middlewares: Option<MW>) -> &Self
     where
         T: OpenApi + 'static,
         D: Clone + Send + Sync + 'static,
+        MW: Middleware<BoxEndpoint<'static>> + Send + 'static,
     {
         let module = WebServerModuleConfig {
             name: self.app_name.clone(),
@@ -72,64 +157,67 @@ impl TardisWebServer {
             ui_path: self.config.ui_path.clone(),
             spec_path: self.config.spec_path.clone(),
         };
-        self.do_add_module_with_data("", &module, apis, data, middlewares).await
+        // self.do_add_module_with_data("", &module, apis, data, middlewares).await
+        todo!()
     }
 
-    pub async fn add_module<T>(&self, code: &str, apis: T, middlewares: impl IntoIterator<Item = BoxMiddleware<'static>> + Send) -> &Self
+    pub async fn add_module<T, MW, D>(&self, code: &str, module: WebServerModule<T, MW, D>) -> &Self
     where
-        T: OpenApi + 'static,
-    {
-        self.add_module_with_data::<_, String>(code, apis, None, middlewares).await
-    }
-
-    pub async fn add_module_with_ws<T>(&self, code: &str, apis: T, capacity: usize, middlewares: impl IntoIterator<Item = BoxMiddleware<'static>> + Send) -> &Self
-    where
-        T: OpenApi + 'static,
-    {
-        self.add_module_with_data::<_, tokio::sync::broadcast::Sender<std::string::String>>(code, apis, Some(tokio::sync::broadcast::channel::<String>(capacity).0), middlewares)
-            .await
-    }
-
-    pub async fn add_module_with_data<T, D>(&self, code: &str, apis: T, data: Option<D>, middlewares: impl IntoIterator<Item = BoxMiddleware<'static>> + Send) -> &Self
-    where
-        T: OpenApi + 'static,
+        T: Clone + Send + Sync + OpenApi + 'static,
         D: Clone + Send + Sync + 'static,
+        MW: Clone + Send + Sync + Middleware<BoxEndpoint<'static>> + 'static,
+    {
+        self.add_module_with_data(code, module).await
+    }
+
+    pub async fn add_module_with_ws<T, MW>(&self, code: &str, apis: T, capacity: usize, middleware: Option<MW>) -> &Self
+    where
+        T: OpenApi + 'static,
+        MW: Middleware<BoxEndpoint<'static>> + Send + 'static,
+    {
+        todo!();
+        // self.add_module_with_data::<_, tokio::sync::broadcast::Sender<std::string::String>, EmptyMiddleWare>(code, apis, Some(tokio::sync::broadcast::channel::<String>(capacity).0), middlewares)
+        //     .await
+    }
+
+    pub async fn add_module_with_data<T, D, MW>(&self, code: &str, module: WebServerModule<T, MW, D>) -> &Self
+    where
+        T: Clone + Send + Sync + OpenApi + 'static,
+        D: Clone + Send + Sync + 'static,
+        MW: Clone + Send + Sync + Middleware<BoxEndpoint<'static>> + 'static,
     {
         let code = code.to_lowercase();
         let code = code.as_str();
-        let module = self.config.modules.get(code).unwrap_or_else(|| panic!("[Tardis.WebServer] Module {code} not found"));
-        self.do_add_module_with_data(code, module, apis, data, middlewares).await
+        let module_config = self.config.modules.get(code).unwrap_or_else(|| panic!("[Tardis.WebServer] Module {code} not found"));
+        self.initializers.lock().await.push(Box::new((code.to_string(), module)));
+        // self.do_add_module_with_data(code, module_config, module).await
+        todo!()
     }
 
-    async fn do_add_module_with_data<T, D>(
-        &self,
-        code: &str,
-        module: &WebServerModuleConfig,
-        apis: T,
-        data: Option<D>,
-        middlewares: impl IntoIterator<Item = BoxMiddleware<'static>>,
-    ) -> &Self
+    async fn do_add_module_with_data<T, MW, D>(&self, code: &str, module_config: &WebServerModuleConfig, module: WebServerModule<T, MW, D>) -> &Self
     where
         T: OpenApi + 'static,
         D: Clone + Send + Sync + 'static,
+        MW: Middleware<BoxEndpoint<'static>> + 'static,
     {
         info!("[Tardis.WebServer] Add module {}", code);
-        let mut api_serv = OpenApiService::new(apis, &module.name, &module.version);
-        for (env, url) in &module.doc_urls {
+        let WebServerModule { apis, data, middleware } = module;
+        let mut api_serv = OpenApiService::new(apis, &module_config.name, &module_config.version);
+        for (env, url) in &module_config.doc_urls {
             let url = if !url.ends_with('/') { format!("{url}/{code}") } else { format!("{url}{code}") };
             api_serv = api_serv.server(ServerObject::new(url).description(env));
         }
-        for (name, desc) in &module.req_headers {
+        for (name, desc) in &module_config.req_headers {
             api_serv = api_serv.extra_request_header::<String, _>(ExtraHeader::new(name).description(desc));
         }
         let ui_serv = api_serv.rapidoc();
         let spec_serv = api_serv.spec_yaml();
         let mut route = Route::new();
         route = route.nest("/", api_serv);
-        if let Some(ui_path) = &module.ui_path {
+        if let Some(ui_path) = &module_config.ui_path {
             route = route.nest(format!("/{ui_path}"), ui_serv);
         }
-        if let Some(spec_path) = &module.spec_path {
+        if let Some(spec_path) = &module_config.spec_path {
             route = route.at(format!("/{spec_path}"), poem::endpoint::make_sync(move |_| spec_serv.clone()));
         }
         let cors = if &self.config.allowed_origin == "*" {
@@ -139,9 +227,11 @@ impl TardisWebServer {
             Cors::new().allow_origin(&self.config.allowed_origin)
         };
         let mut route = route.boxed();
-        for middleware in middlewares {
-            route = middleware.transform(route);
-        }
+        let route = route.with(middleware);
+        // let route = middleware.transform(route);
+        // for middleware in middlewares {
+        //     route = middleware.transform(route);
+        // }
         let route = route.with(UniformError).with(cors);
         // Solved:  Cannot move out of *** which is behind a mutable reference
         // https://stackoverflow.com/questions/63353762/cannot-move-out-of-which-is-behind-a-mutable-reference
@@ -157,12 +247,14 @@ impl TardisWebServer {
 
     pub async fn add_module_raw(&self, code: &str, route: Route) -> &Self {
         let mut swap_route = Route::new();
-        std::mem::swap(&mut swap_route, &mut *self.route.lock().await);
-        *self.route.lock().await = swap_route.nest(format!("/{code}"), route);
+        // std::mem::swap(&mut swap_route, &mut *self.route.lock().await);
+        // *self.route.lock().await = swap_route.nest(format!("/{code}"), route);
         self
     }
-
     pub async fn start(&self) -> TardisResult<()> {
+        for initializer in self.initializers.lock().await.iter() {
+            initializer.init(self).await;
+        }
         let output_info = format!(
             r#"
 =================

--- a/tardis/src/web/web_server/initializer.rs
+++ b/tardis/src/web/web_server/initializer.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+#[async_trait::async_trait]
+pub(crate) trait Initializer {
+    async fn init(&self, target: &TardisWebServer);
+}
+
+/// a tuple of (Code, WebServerModule) can be an initializer
+#[async_trait::async_trait]
+impl<T, MW, D> Initializer for (String, WebServerModule<T, MW, D>)
+where
+    T: Clone + OpenApi + 'static + Send + Sync,
+    MW: Clone + Middleware<BoxEndpoint<'static>> + 'static + Send + Sync,
+    D: Clone + Send + Sync + 'static,
+{
+    async fn init(&self, target: &TardisWebServer) {
+        let (code, ref module) = self;
+        let module_config = target.config.modules.get(code).unwrap_or_else(|| panic!("[Tardis.WebServer] Module {code} not found")).clone();
+        target.do_add_module_with_data(code, &module_config, module.clone()).await;
+    }
+}
+
+/// a tuple of (Code, WebServerModule, Config) can be an initializer, in this case we don't load config manually
+#[async_trait::async_trait]
+impl<T, MW, D> Initializer for (String, WebServerModule<T, MW, D>, WebServerModuleConfig)
+where
+    T: Clone + OpenApi + 'static + Send + Sync,
+    MW: Clone + Middleware<BoxEndpoint<'static>> + 'static + Send + Sync,
+    D: Clone + Send + Sync + 'static,
+{
+    async fn init(&self, target: &TardisWebServer) {
+        let (code, ref module, module_config) = self;
+        target.do_add_module_with_data(code, module_config, module.clone()).await;
+    }
+}
+
+/// `TardisWebServer` itself can serve as an `Initializer`, it applies all of it's initializer to another
+/// it will consume all initializer of stored previous webserver
+#[async_trait::async_trait]
+impl Initializer for TardisWebServer {
+    #[inline]
+    async fn init(&self, target: &TardisWebServer) {
+        let mut target_initializers = target.initializers.lock().await;
+        for i in self.initializers.lock().await.drain(..) {
+            i.init(target).await;
+            target_initializers.push(i);
+        }
+    }
+}
+
+impl TardisWebServer {
+    /// Load an single initializer
+    #[inline]
+    pub(crate) async fn load_initializer(&self, initializer: impl Initializer + Send + Sync + 'static) {
+        self.load_boxed_initializer(Box::new(initializer)).await;
+    }
+
+    /// Load an single boxed initializer
+    pub(crate) async fn load_boxed_initializer(&self, initializer: Box<dyn Initializer + Send + Sync>) {
+        initializer.init(self).await;
+        self.initializers.lock().await.push(initializer);
+    }
+}

--- a/tardis/src/web/web_server/module.rs
+++ b/tardis/src/web/web_server/module.rs
@@ -1,5 +1,6 @@
 use poem::{Middleware, endpoint::BoxEndpoint};
 use poem_openapi::OpenApi;
+use tokio::sync::broadcast;
 
 
 #[derive(Clone)]
@@ -50,10 +51,10 @@ impl<T, _MW, _D> WebServerModule<T, _MW, _D> {
     /// ```no_run
     /// WebServerModule::from(MyApi).with_ws(100);
     /// ```
-    pub fn with_ws(self, capacity: usize) -> WebServerModule<T, _MW, tokio::sync::broadcast::Sender::<String>> {
+    pub fn with_ws(self, capacity: usize) -> WebServerModule<T, _MW, broadcast::Sender::<String>> {
         WebServerModule {
             apis: self.apis,
-            data: Some(tokio::sync::broadcast::channel(capacity).0),
+            data: Some(broadcast::channel(capacity).0),
             middleware: self.middleware,
         }
     }

--- a/tardis/src/web/web_server/module.rs
+++ b/tardis/src/web/web_server/module.rs
@@ -1,0 +1,92 @@
+use poem::{Middleware, endpoint::BoxEndpoint};
+use poem_openapi::OpenApi;
+
+
+#[derive(Clone)]
+pub struct WebServerModule<T, MW = EmptyMiddleWare, D = ()> {
+    pub apis: T,
+    pub data: Option<D>,
+    pub middleware: MW,
+}
+
+impl<T> From<T> for WebServerModule<T> 
+where T: OpenApi
+{
+    fn from(apis: T) -> Self {
+        WebServerModule::new(apis)
+    }
+}
+
+impl<T, MW> From<(T, MW)> for WebServerModule<T, MW>
+where MW: Middleware<BoxEndpoint<'static>>
+{
+    fn from(value: (T, MW)) -> Self {
+        let (apis, mw) = value;
+        WebServerModule::new(apis).middleware(mw)
+    }
+}
+
+impl<T, MW, D> From<(T, MW, D)> for WebServerModule<T, MW, D>
+where MW: Middleware<BoxEndpoint<'static>>
+{
+    fn from(value: (T, MW, D)) -> Self {
+        let (apis, mw, data) = value;
+        WebServerModule::new(apis).middleware(mw).data(data)
+    }
+}
+
+impl<T> WebServerModule<T> {
+    pub fn new(apis: T) -> Self {
+        Self {
+            apis,
+            data: None,
+            middleware: EMPTY_MW,
+        }
+    }
+}
+
+impl<T, _MW, _D> WebServerModule<T, _MW, _D> {
+    /// create a module with tokio broadcast sender as data
+    /// ```no_run
+    /// WebServerModule::from(MyApi).with_ws(100);
+    /// ```
+    pub fn with_ws(self, capacity: usize) -> WebServerModule<T, _MW, tokio::sync::broadcast::Sender::<String>> {
+        WebServerModule {
+            apis: self.apis,
+            data: Some(tokio::sync::broadcast::channel(capacity).0),
+            middleware: self.middleware,
+        }
+    }
+
+    pub fn data<D>(self, data: D) -> WebServerModule<T, _MW, D> {
+        WebServerModule {
+            apis: self.apis,
+            data: Some(data),
+            middleware: self.middleware,
+        }
+    }
+
+    pub fn middleware<MW>(self, middleware: MW) -> WebServerModule<T, MW, _D> {
+        WebServerModule {
+            apis: self.apis,
+            data: self.data,
+            middleware,
+        }
+    }
+}
+
+/// A middleware will do nothing
+#[derive(Debug, Copy, Clone)]
+pub struct EmptyMiddleWare;
+
+/// A middleware will do nothing
+pub const EMPTY_MW: EmptyMiddleWare = EmptyMiddleWare;
+
+impl Middleware<BoxEndpoint<'static>> for EmptyMiddleWare {
+    type Output = BoxEndpoint<'static>;
+
+    fn transform(&self, ep: BoxEndpoint<'static>) -> Self::Output {
+        // literally do nothing
+        ep
+    }
+}

--- a/tardis/src/web/web_server/module.rs
+++ b/tardis/src/web/web_server/module.rs
@@ -1,7 +1,6 @@
-use poem::{Middleware, endpoint::BoxEndpoint};
+use poem::{endpoint::BoxEndpoint, Middleware};
 use poem_openapi::OpenApi;
 use tokio::sync::broadcast;
-
 
 #[derive(Clone)]
 pub struct WebServerModule<T, MW = EmptyMiddleWare, D = ()> {
@@ -10,8 +9,9 @@ pub struct WebServerModule<T, MW = EmptyMiddleWare, D = ()> {
     pub middleware: MW,
 }
 
-impl<T> From<T> for WebServerModule<T> 
-where T: OpenApi
+impl<T> From<T> for WebServerModule<T>
+where
+    T: OpenApi,
 {
     fn from(apis: T) -> Self {
         WebServerModule::new(apis)
@@ -19,7 +19,8 @@ where T: OpenApi
 }
 
 impl<T, MW> From<(T, MW)> for WebServerModule<T, MW>
-where MW: Middleware<BoxEndpoint<'static>>
+where
+    MW: Middleware<BoxEndpoint<'static>>,
 {
     fn from(value: (T, MW)) -> Self {
         let (apis, mw) = value;
@@ -28,7 +29,8 @@ where MW: Middleware<BoxEndpoint<'static>>
 }
 
 impl<T, MW, D> From<(T, MW, D)> for WebServerModule<T, MW, D>
-where MW: Middleware<BoxEndpoint<'static>>
+where
+    MW: Middleware<BoxEndpoint<'static>>,
 {
     fn from(value: (T, MW, D)) -> Self {
         let (apis, mw, data) = value;
@@ -51,7 +53,7 @@ impl<T, _MW, _D> WebServerModule<T, _MW, _D> {
     /// ```no_run
     /// WebServerModule::from(MyApi).with_ws(100);
     /// ```
-    pub fn with_ws(self, capacity: usize) -> WebServerModule<T, _MW, broadcast::Sender::<String>> {
+    pub fn with_ws(self, capacity: usize) -> WebServerModule<T, _MW, broadcast::Sender<String>> {
         WebServerModule {
             apis: self.apis,
             data: Some(broadcast::channel(capacity).0),

--- a/tardis/src/web/web_server/module.rs
+++ b/tardis/src/web/web_server/module.rs
@@ -86,7 +86,7 @@ impl<T> WebServerModule<T> {
 
 impl<T, _MW, _D> WebServerModule<T, _MW, _D> {
     /// create a module with tokio broadcast sender as data
-    /// ```no_run
+    /// ```ignore
     /// WebServerModule::from(MyApi).with_ws(100);
     /// ```
     pub fn with_ws(self, capacity: usize) -> WebServerModule<T, _MW, broadcast::Sender<String>> {

--- a/tardis/tests/config/remote-config/conf-remote-v2.toml
+++ b/tardis/tests/config/remote-config/conf-remote-v2.toml
@@ -5,7 +5,7 @@ id = "test-app"
 [fw.web_server]
 enabled = true
 host="0.0.0.0"
-port=8081
+port=8080
 allowed_origin="*"
 spec_path="spec"
 ui_path="ui"

--- a/tardis/tests/config/remote-config/conf-remote-v2.toml
+++ b/tardis/tests/config/remote-config/conf-remote-v2.toml
@@ -4,7 +4,7 @@ id = "test-app"
 
 [fw.web_server]
 enabled = true
-host="0.0.0.0"
+host="localhost"
 port=8080
 allowed_origin="*"
 spec_path="spec"

--- a/tardis/tests/test_config_with_remote.rs
+++ b/tardis/tests/test_config_with_remote.rs
@@ -169,10 +169,10 @@ async fn test_config_with_remote() -> TardisResult<()> {
     assert_eq!(TardisFuns::cs_config::<TestConfig>("").project_name, "测试_romote_uploaded_v2");
     // 5.1 test if web server router is still usable
     {
-        let result = TardisFuns::web_client().get_to_str("http://localhost:8080/hello", None).await?;
-        assert_eq!(result.code, StatusCode::OK.as_u16());
+        let response = TardisFuns::web_client().get_to_str("http://localhost:8080/hello", None).await?;
+        assert_eq!(response.code, StatusCode::OK.as_u16());
         // rand key should be same
-        assert_eq!(result.body.unwrap(), key);
+        assert!(response.body.unwrap().contains(&key));
     }
     // wait for server to start
     // 5.2 test mq

--- a/tardis/tests/test_config_with_remote.rs
+++ b/tardis/tests/test_config_with_remote.rs
@@ -193,7 +193,6 @@ async fn test_config_with_remote() -> TardisResult<()> {
         header.insert("k1".to_string(), "v1".to_string());
 
         mq_client.request("test-addr", "测试!".to_string(), &header).await?;
-
     }
 
     TardisFuns::shutdown().await?;

--- a/tardis/tests/test_search_client.rs
+++ b/tardis/tests/test_search_client.rs
@@ -65,7 +65,6 @@ async fn test_search_client() -> TardisResult<()> {
         client.create_index(index_name).await?;
         assert!(client.check_index_exist(index_name).await?);
         assert!(!client.check_index_exist("test_index_copy").await?);
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         client.create_record(index_name, r#"{"user":{"id":1,"name":"张三","open":false}}"#).await?;
         client.create_record(index_name, r#"{"user":{"id":2,"name":"李四","open":false}}"#).await?;

--- a/tardis/tests/test_search_client.rs
+++ b/tardis/tests/test_search_client.rs
@@ -65,6 +65,7 @@ async fn test_search_client() -> TardisResult<()> {
         client.create_index(index_name).await?;
         assert!(client.check_index_exist(index_name).await?);
         assert!(!client.check_index_exist("test_index_copy").await?);
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         client.create_record(index_name, r#"{"user":{"id":1,"name":"张三","open":false}}"#).await?;
         client.create_record(index_name, r#"{"user":{"id":2,"name":"李四","open":false}}"#).await?;

--- a/tardis/tests/test_web_server.rs
+++ b/tardis/tests/test_web_server.rs
@@ -539,67 +539,66 @@ async fn test_context(url: &str) -> TardisResult<()> {
 async fn test_security() -> TardisResult<()> {
     let url = "https://localhost:8081";
     TardisFuns::shutdown().await?;
-    tokio::spawn(async {
-        TardisFuns::init_conf(TardisConfig {
-            cs: Default::default(),
-            fw: FrameworkConfig {
-                app: Default::default(),
-                web_server: WebServerConfig {
-                    enabled: true,
-                    port: 8081,
-                    modules: HashMap::from([
-                        (
-                            "todo".to_string(),
-                            WebServerModuleConfig {
-                                name: "todo app".to_string(),
-                                doc_urls: [("test env".to_string(), url.to_string()), ("prod env".to_string(), "http://127.0.0.1".to_string())].to_vec(),
-                                ..Default::default()
-                            },
-                        ),
-                        (
-                            "other".to_string(),
-                            WebServerModuleConfig {
-                                name: "other app".to_string(),
-                                ..Default::default()
-                            },
-                        ),
-                    ]),
-                    tls_key: Some(TLS_KEY.to_string()),
-                    tls_cert: Some(TLS_CERT.to_string()),
-                    security_hide_err_msg: true,
-                    ..Default::default()
-                },
-                web_client: Default::default(),
-                cache: CacheConfig {
-                    enabled: false,
-                    ..Default::default()
-                },
-                db: DBConfig {
-                    enabled: false,
-                    ..Default::default()
-                },
-                mq: MQConfig {
-                    enabled: false,
-                    ..Default::default()
-                },
-                search: SearchConfig {
-                    enabled: false,
-                    ..Default::default()
-                },
-                mail: MailConfig {
-                    enabled: false,
-                    ..Default::default()
-                },
-                os: OSConfig {
-                    enabled: false,
-                    ..Default::default()
-                },
+    TardisFuns::init_conf(TardisConfig {
+        cs: Default::default(),
+        fw: FrameworkConfig {
+            app: Default::default(),
+            web_server: WebServerConfig {
+                enabled: true,
+                port: 8081,
+                modules: HashMap::from([
+                    (
+                        "todo".to_string(),
+                        WebServerModuleConfig {
+                            name: "todo app".to_string(),
+                            doc_urls: [("test env".to_string(), url.to_string()), ("prod env".to_string(), "http://127.0.0.1".to_string())].to_vec(),
+                            ..Default::default()
+                        },
+                    ),
+                    (
+                        "other".to_string(),
+                        WebServerModuleConfig {
+                            name: "other app".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                ]),
+                tls_key: Some(TLS_KEY.to_string()),
+                tls_cert: Some(TLS_CERT.to_string()),
+                security_hide_err_msg: true,
                 ..Default::default()
             },
-        })
-        .await?;
-        TardisFuns::web_server().add_module("todo", WebServerModule::new(TodosApi)).await.add_module("other", WebServerModule::new(OtherApi)).await.start().await
-    });
+            web_client: Default::default(),
+            cache: CacheConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            db: DBConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            mq: MQConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            search: SearchConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            mail: MailConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            os: OSConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    })
+    .await?;
+    TardisFuns::web_server().add_module("todo", WebServerModule::new(TodosApi)).await.add_module("other", WebServerModule::new(OtherApi)).await.start().await?;
+
     sleep(Duration::from_millis(500)).await;
 
     // Normal

--- a/tardis/tests/test_web_server.rs
+++ b/tardis/tests/test_web_server.rs
@@ -597,7 +597,7 @@ async fn test_security() -> TardisResult<()> {
         },
     })
     .await?;
-    TardisFuns::web_server().add_module("todo", WebServerModule::new(TodosApi)).await.add_module("other", WebServerModule::new(OtherApi)).await.start().await?;
+    TardisFuns::web_server().add_module("todo", TodosApi).await.add_module("other", OtherApi).await.start().await?;
 
     sleep(Duration::from_millis(500)).await;
 
@@ -727,7 +727,7 @@ async fn test_middleware() -> TardisResult<()> {
         TardisFuns::web_server()
             .add_module("todo", WebServerModule::new(TodosApi).middleware((TodosApiMiddleware1, TodosApiMiddleware2)))
             .await
-            .add_module("other", WebServerModule::new(OtherApi))
+            .add_module("other", OtherApi)
             .await
             .start()
             .await

--- a/tardis/tests/test_web_server.rs
+++ b/tardis/tests/test_web_server.rs
@@ -11,7 +11,7 @@ use poem::endpoint::BoxEndpoint;
 use poem::{IntoResponse, Middleware, Response};
 use reqwest::Method;
 use serde_json::json;
-use tardis::web::web_server::{WebServerModule};
+use tardis::web::web_server::WebServerModule;
 use testcontainers::clients;
 use tokio::time::sleep;
 use tracing::info;

--- a/tardis/tests/test_web_server.rs
+++ b/tardis/tests/test_web_server.rs
@@ -11,7 +11,7 @@ use poem::endpoint::BoxEndpoint;
 use poem::{IntoResponse, Middleware, Response};
 use reqwest::Method;
 use serde_json::json;
-use tardis::web::web_server::BoxMiddleware;
+use tardis::web::web_server::{BoxMiddleware, EMPTY_MW};
 use testcontainers::clients;
 use tokio::time::sleep;
 use tracing::info;
@@ -167,7 +167,7 @@ async fn start_serv(web_url: &str, redis_url: &str) -> TardisResult<()> {
         },
     })
     .await?;
-    TardisFuns::web_server().add_module("todo", TodosApi, None).await.add_module_with_data::<_, String>("other", OtherApi, None, None).await.start().await
+    TardisFuns::web_server().add_module("todo", TodosApi, EMPTY_MW).await.add_module_with_data::<_, String, _>("other", OtherApi, None, EMPTY_MW).await.start().await
 }
 
 async fn test_basic(url: &str) -> TardisResult<()> {
@@ -596,7 +596,7 @@ async fn test_security() -> TardisResult<()> {
             },
         })
         .await?;
-        TardisFuns::web_server().add_module("todo", TodosApi, vec![]).await.add_module_with_data::<_, String>("other", OtherApi, None, None).await.start().await
+        TardisFuns::web_server().add_module("todo", TodosApi, EMPTY_MW).await.add_module_with_data::<_, String, _>("other", OtherApi, None, EMPTY_MW).await.start().await
     });
     sleep(Duration::from_millis(500)).await;
 
@@ -724,8 +724,8 @@ async fn test_middleware() -> TardisResult<()> {
         })
         .await?;
         TardisFuns::web_server()
-            .add_module("todo", TodosApi, vec![TodosApiMiddleware1::boxed(), TodosApiMiddleware2::boxed()])
-            .await
+        .await
+        .add_module("todo", TodosApi, Some((TodosApiMiddleware1, TodosApiMiddleware2)))
             .add_module_with_data::<_, String>("other", OtherApi, None, None)
             .await
             .start()

--- a/tardis/tests/test_websocket.rs
+++ b/tardis/tests/test_websocket.rs
@@ -8,7 +8,7 @@ use poem::web::websocket::{BoxWebSocketUpgraded, WebSocket};
 use poem_openapi::param::Path;
 use serde_json::json;
 use tardis::basic::result::TardisResult;
-use tardis::web::web_server::TardisWebServer;
+use tardis::web::web_server::{TardisWebServer, WebServerModule};
 use tardis::web::ws_processor::{
     ws_broadcast, ws_echo, TardisWebsocketInstInfo, TardisWebsocketMessage, TardisWebsocketMgrMessage, TardisWebsocketReq, TardisWebsocketResp, WS_SYSTEM_EVENT_AVATAR_ADD,
     WS_SYSTEM_EVENT_AVATAR_DEL, WS_SYSTEM_EVENT_INFO,
@@ -25,11 +25,9 @@ lazy_static! {
 
 #[tokio::test]
 async fn test_websocket() -> TardisResult<()> {
-    tokio::spawn(async {
-        let serv = TardisWebServer::init_simple("127.0.0.1", 8080).unwrap();
-        serv.add_route_with_ws(Api, 100).await;
-        serv.start().await
-    });
+    let serv = TardisWebServer::init_simple("127.0.0.1", 8080).unwrap();
+    serv.add_route(WebServerModule::from(Api).with_ws(100)).await;
+    serv.start().await?;
     sleep(Duration::from_millis(500)).await;
 
     test_normal().await?;
@@ -327,6 +325,7 @@ async fn test_dyn_avatar() -> TardisResult<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone)]
 struct Api;
 
 #[poem_openapi::OpenApi]


### PR DESCRIPTION
# Refactor `TardisWebServer`
## Modify `add_module` and `add_route`
`TardisWebServer` now load modules by structure `WebServerModule`
```rust
  pub async fn add_module<T, MW, D>(&self, code: &str, module: impl Into<WebServerModule<T, MW, D>>) -> &Self;
  where
      T: Clone + Send + Sync + OpenApi + 'static,
      D: Clone + Send + Sync + 'static,
      MW: Clone + Send + Sync + Middleware<BoxEndpoint<'static>> + 'static,
```
this function serve as `add_module_with_ws`, `add_module_with_data`, `add_module` of previous version, it reveives a module code and something that can be convert into a `WebServerModule` structrue.
In [module.rs](/tardis/src/web/web_server/module.rs), I implement `Into<WebServerModule>` for some types including `Api`, `(Api, MiddleWare)`, `(Api, MiddleWare, Data)`, so it's OK to do so:
```rust
webserver.add_module(code, api).await;
webserver.add_module(code, (api, middleware)).await;
webserver.add_module(code, (api, EMPTY_MW, data)).await;
```
or just construct an `WebServerModule`
```rust
webserver.add_module(code, WebServerModule::from(api).data(data)).await;
webserver.add_module(code, WebServerModule::from(api).data(data)).middleware(middleware).await;
// add ws api
webserver.add_module(code, WebServerModule::from(api).with_ws(ws_capacity)).await;
```
and it's the same with add_route
## Record added modules
Now routes and modules added into webserver will be converted into an [`Initializer`](tardis/src/web/web_server/initializer.rs), and initializers applied on webservers will be stored. When server is going to be restarted, old webserver will serve as an `Initializer` to initialize the new webserver.
1. when add modules, api, mw and datas will be converted into an boxed `Initializer`
```rust
self.load_initializer((code.to_string(), module.into())).await;
```
2. in `load_initializer`, `Initializer::init()` will be called and it will modify webserver's route.
3. when restart, initializers stored by old webserver's will be drained out and loaded by new webserver.
## Storing server state
now server has a field called "state"
```rust
/// Server status hold by `TardisWebServer`
enum ServerState {
    /// ## Server is not running
    /// in that case, it hold route info
    Halted(Route),
    /// ## Server is running
    /// in that case, it hold join handle
    Running(ServerTask),
}
```
After `start()` is called, webserver will be spawned and join handle will be stored, state turns into `ServerState::Running`, until `ctrl_c` signal is received or `TardisWebServer::shutdown()` is called.

Now we can't call `webserver.start().await` to block current thread any more. This function will return immediately after server stats became `Running`. Instead, we can directly await on webserver itself.
- previous
```rust
let h = tokio::spawn(TardisFuns::web_server().start());
// do something
h.await;
```
- now
```rust
TardisFuns::web_server().start().awiat?;
// do something
TardisFuns::web_server().await;
```

The advantages:
1. we can positively, explicitly shutdown the webserver and wait until it is **indeed** shutted down, only then we can safely start a new server on the same port
2. if we wrongly add routes when server is running, or shutdown an halted server, at least we can got an error log.

# Using module by module reload instead of shutdown-initialize
when config was changed, `hot_reload()` is called instead of `shutdown()`, so we can ensure webserver would'n be reloaded if webserver config hasn't changed.
