### PR TITLE
fix: shutdown existed web-server before init it

### DIFF
--- a/tardis/src/lib.rs
+++ b/tardis/src/lib.rs
@@ -433,9 +433,13 @@ impl TardisFuns {
                     };
                     // if there's some inherit webserver
                     if let Some(inherit) = inherit {
-                        // 1. load initializers
+                        // 1. should always shutdown first
+                        if let Err(e) = inherit.shutdown().await {
+                            log::error!("[Tardis.WebServer] encounter an error when trying to shutdown webserver: {e}")
+                        }
+                        // 2. load initializers
                         web_server.load_initializer(inherit).await;
-                        // 2. restart webserver
+                        // 3. restart webserver
                         web_server.start().await?;
                     }
                     replace(&mut TARDIS_INST.web_server, Some(web_server));

--- a/tardis/src/web/web_server.rs
+++ b/tardis/src/web/web_server.rs
@@ -321,6 +321,12 @@ impl TardisWebServer {
         drop(state_locked);
         Ok(())
     }
+
+    /// return true if web server is running
+    pub async fn is_running(&self) -> bool {
+        let state = &*self.state.lock().await;
+        matches!(state, ServerState::Running(t) if !t.inner.is_finished())
+    }
 }
 
 /// this await will pending until server is closed

--- a/tardis/src/web/ws_client.rs
+++ b/tardis/src/web/ws_client.rs
@@ -45,7 +45,12 @@ where
                 url.clone(),
                 None,
                 false,
-                Some(Connector::NativeTls(TlsConnector::builder().danger_accept_invalid_certs(true).build().unwrap())),
+                Some(Connector::NativeTls(TlsConnector::builder().danger_accept_invalid_certs(true).build().map_err(|e| {
+                    TardisError::format_error(
+                        &format!("[Tardis.WSClient] Failed to build tls connector: {e}"),
+                        "500-tardis-ws-client-build-connector-error",
+                    )
+                })?)),
             )
             .await
         };
@@ -80,7 +85,7 @@ where
     }
 
     pub async fn send_obj<E: ?Sized + Serialize>(&self, msg: &E) -> TardisResult<()> {
-        let message = TardisFuns::json.obj_to_string(msg).unwrap();
+        let message = TardisFuns::json.obj_to_string(msg)?;
         self.send_text(message).await
     }
 


### PR DESCRIPTION
1. shutdown exsited web-server before init it, in case of someone called `init_conf` twice without calling `shutdown`
2. nacosclient.reqwest_execute receives a closure or function
3. add an `is_running` method for webserver