### PR TITLE
fix: Lapin using tokio runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ out
 # Cargo
 Cargo.lock
 target
+.cargo
 
 # gh pages docs
 util/gh-pages/lints.json

--- a/tardis/Cargo.toml
+++ b/tardis/Cargo.toml
@@ -148,9 +148,9 @@ redis = { version = "0.23", features = [
 deadpool-redis = { version = "0.12", optional = true }
 
 # Rabbit
-lapin = { version = "2.0", optional = true }
+lapin = { version = "2", optional = true }
 amq-protocol-types = { version = "7.0", optional = true }
-async-global-executor = { version = "2.0", optional = true }
+async-global-executor = { version = "2", optional = true, features = ["tokio"] }
 
 # Mail
 lettre = { version = "0.10.4", features = [
@@ -165,12 +165,13 @@ rust-s3 = { version = "0.33", optional = true }
 anyhow = { version = "1.0", optional = true }
 
 # Test
-testcontainers = { version = "0.14", optional = true }
+testcontainers = { version = "0.14.0", optional = true }
 
 [dev-dependencies]
 # Common
 tokio = { version = "1", features = ["time", "rt", "macros", "sync"] }
 criterion = { version = "0.5" }
+console-subscriber = "0.1.10"
 
 [[test]]
 name = "test_config"

--- a/tardis/src/crypto/crypto_key.rs
+++ b/tardis/src/crypto/crypto_key.rs
@@ -7,37 +7,37 @@ pub struct TardisCryptoKey;
 impl TardisCryptoKey {
     pub fn rand_8_hex(&self) -> TardisResult<String> {
         let mut key: [u8; 4] = [0; 4];
-        rand::rngs::OsRng::default().fill_bytes(&mut key);
+        rand::rngs::OsRng.fill_bytes(&mut key);
         Ok(hex::encode(key))
     }
 
     pub fn rand_16_hex(&self) -> TardisResult<String> {
         let mut key: [u8; 8] = [0; 8];
-        rand::rngs::OsRng::default().fill_bytes(&mut key);
+        rand::rngs::OsRng.fill_bytes(&mut key);
         Ok(hex::encode(key))
     }
 
     pub fn rand_32_hex(&self) -> TardisResult<String> {
         let mut key: [u8; 16] = [0; 16];
-        rand::rngs::OsRng::default().fill_bytes(&mut key);
+        rand::rngs::OsRng.fill_bytes(&mut key);
         Ok(hex::encode(key))
     }
 
     pub fn rand_64_hex(&self) -> TardisResult<String> {
         let mut key: [u8; 32] = [0; 32];
-        rand::rngs::OsRng::default().fill_bytes(&mut key);
+        rand::rngs::OsRng.fill_bytes(&mut key);
         Ok(hex::encode(key))
     }
 
     pub fn rand_128_hex(&self) -> TardisResult<String> {
         let mut key: [u8; 64] = [0; 64];
-        rand::rngs::OsRng::default().fill_bytes(&mut key);
+        rand::rngs::OsRng.fill_bytes(&mut key);
         Ok(hex::encode(key))
     }
 
     pub fn rand_256_hex(&self) -> TardisResult<String> {
         let mut key: [u8; 128] = [0; 128];
-        rand::rngs::OsRng::default().fill_bytes(&mut key);
+        rand::rngs::OsRng.fill_bytes(&mut key);
         Ok(hex::encode(key))
     }
 

--- a/tardis/src/search/search_client.rs
+++ b/tardis/src/search/search_client.rs
@@ -315,7 +315,7 @@ impl TardisSearchClient {
         let mut source_vec = vec![];
         let mut params_vec = vec![];
         for (key, value) in q {
-            let param_key = key.replace(".", "_");
+            let param_key = key.replace('.', "_");
             source_vec.push(format!(r#"ctx._source.{key}= params.{param_key}"#));
             params_vec.push(format!(r#""{param_key}": {value}"#));
         }

--- a/tardis/src/test/test_container.rs
+++ b/tardis/src/test/test_container.rs
@@ -30,7 +30,7 @@ impl TardisTestContainer {
     }
 
     pub fn redis_custom(docker: &Cli) -> Container<Redis> {
-        docker.run(images::redis::Redis::default())
+        docker.run(images::redis::Redis)
     }
 
     pub async fn rabbit<F, T>(fun: F) -> TardisResult<()>

--- a/tardis/tests/config/remote-config/conf-remote-v1.toml
+++ b/tardis/tests/config/remote-config/conf-remote-v1.toml
@@ -10,6 +10,9 @@ allowed_origin="*"
 spec_path="spec"
 ui_path="ui"
 
+[fw.cache]
+enabled = true
+
 # test-app-default in remote
 # [cs]
 # project_name = "测试_romote_default"

--- a/tardis/tests/config/remote-config/conf-remote-v2.toml
+++ b/tardis/tests/config/remote-config/conf-remote-v2.toml
@@ -10,6 +10,9 @@ allowed_origin="*"
 spec_path="spec"
 ui_path="ui"
 
+[fw.cache]
+enabled = true
+
 # test-app-default in remote
 # [cs]
 # project_name = "测试_romote_default"

--- a/tardis/tests/test_mq_client.rs
+++ b/tardis/tests/test_mq_client.rs
@@ -11,10 +11,11 @@ use tardis::TardisFuns;
 
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_mq_client() -> TardisResult<()> {
     env::set_var("RUST_LOG", "info,tardis=trace");
-    TardisFuns::init_log()?;
+    console_subscriber::init();
+    // TardisFuns::init_log()?;
     TardisTestContainer::rabbit(|url| async move {
         // Default test
         TardisFuns::init_conf(TardisConfig {
@@ -58,10 +59,11 @@ async fn test_mq_client() -> TardisResult<()> {
 
         TardisFuns::mq();
         let client = TardisFuns::mq_by_module("m1");
-
         client
-            .response("test-addr", |(header, msg)| async move {
+            .response("test-addr", move |(header, msg)| async move {
                 println!("response1 {}", msg);
+                // tokio current thread runtime + tokio await point + lapin may block tokio task(only polled a few times)
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
                 assert_eq!(header.get("k1").unwrap(), "v1");
                 assert_eq!(msg, "测试!");
                 COUNTER.fetch_add(1, Ordering::SeqCst);
@@ -114,6 +116,7 @@ async fn test_mq_client() -> TardisResult<()> {
 
         loop {
             if COUNTER.load(Ordering::SeqCst) == 12 {
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
                 break;
             }
         }

--- a/tardis/tests/test_mq_client.rs
+++ b/tardis/tests/test_mq_client.rs
@@ -14,8 +14,9 @@ static COUNTER: AtomicUsize = AtomicUsize::new(0);
 #[tokio::test(flavor = "multi_thread")]
 async fn test_mq_client() -> TardisResult<()> {
     env::set_var("RUST_LOG", "info,tardis=trace");
-    console_subscriber::init();
-    // TardisFuns::init_log()?;
+    // enable when debug tokio
+    // console_subscriber::init();
+    TardisFuns::init_log()?;
     TardisTestContainer::rabbit(|url| async move {
         // Default test
         TardisFuns::init_conf(TardisConfig {


### PR DESCRIPTION
1. using tokio runtime for lapin
- Default runtime of lapin is `async-io`, it will panic when awaiting tokio task in lapin response code.
- Make mq test multithread. It seems like the main thread could be blocked by lapin so the async responsor can't run across an await point
2. add cache test for remote config test
3. clippy fix and cargo fmt