### PR TITLE
fix: docker use local addr instead of bridge addr

### DIFF
--- a/tardis/Cargo.toml
+++ b/tardis/Cargo.toml
@@ -165,7 +165,7 @@ rust-s3 = { version = "0.33", optional = true }
 anyhow = { version = "1.0", optional = true }
 
 # Test
-testcontainers = { version = "0.14.0", optional = true }
+testcontainers = { version = "0.14", optional = true }
 
 [dev-dependencies]
 # Common

--- a/tardis/tests/test_config_with_remote.rs
+++ b/tardis/tests/test_config_with_remote.rs
@@ -63,7 +63,7 @@ fn initialize_docker_env(cli: &Cli) -> DockerEnv {
         .mode(NacosServerMode::Standalone);
     nacos.tag = "v2.1.1-slim".to_string();
     let nacos = cli.run(nacos);
-    let nacos_url = format!("{schema}://{ip}:{port}/nacos", schema = "http", ip = nacos.get_bridge_ip_address(), port = 8848);
+    let nacos_url = format!("{schema}://{ip}:{port}/nacos", schema = "http", ip = "127.0.0.1", port = nacos.get_host_port_ipv4(8848));
     env::set_var("TARDIS_FW.CONF_CENTER.URL", nacos_url.clone());
     nacos.start();
     println!("nacos server started at: {}", nacos_url);
@@ -75,8 +75,8 @@ fn initialize_docker_env(cli: &Cli) -> DockerEnv {
         schema = "amqp",
         user = "guest",
         pswd = "guest",
-        ip = mq.get_bridge_ip_address(),
-        port = 5672
+        ip = "127.0.0.1",
+        port = mq.get_host_port_ipv4(5672)
     );
     env::set_var("TARDIS_FW.MQ.URL", mq_url.clone());
     env::set_var("TARDIS_FW.MQ.MODULES.M1.URL", mq_url.clone());
@@ -103,7 +103,6 @@ async fn test_config_with_remote() -> TardisResult<()> {
 
     let docker = testcontainers::clients::Cli::docker();
     let docker_env = initialize_docker_env(&docker);
-    // let nacos_url = format!("{schema}://{ip}:{port}/nacos", schema = "http", ip = "0.0.0.0", port = 8848);
     TardisFuns::init(Some("tests/config")).await?;
     assert_eq!(TardisFuns::cs_config::<TestConfig>("").project_name, "测试_romote_locale");
     assert_eq!(TardisFuns::cs_config::<TestConfig>("").level_num, 3);

--- a/tardis/tests/test_config_with_remote.rs
+++ b/tardis/tests/test_config_with_remote.rs
@@ -47,6 +47,8 @@ struct DockerEnv<'d> {
     cache: Container<'d, Redis>,
 }
 
+const NACOS_TAG: &str = "v2.2.3-slim";
+
 fn initialize_docker_env(cli: &Cli) -> DockerEnv {
     // init nacos docker
     use tardis::test::test_container::nacos_server::NacosServerMode;
@@ -61,7 +63,7 @@ fn initialize_docker_env(cli: &Cli) -> DockerEnv {
         .nacos_auth_token(tardis::crypto::crypto_base64::TardisCryptoBase64.encode("nacos server for test_config_with_remote"))
         .nacos_auth_token_expire_seconds(10)
         .mode(NacosServerMode::Standalone);
-    nacos.tag = "v2.1.1-slim".to_string();
+    nacos.tag = NACOS_TAG.to_string();
     let nacos = cli.run(nacos);
     let nacos_url = format!("{schema}://{ip}:{port}/nacos", schema = "http", ip = "127.0.0.1", port = nacos.get_host_port_ipv4(8848));
     env::set_var("TARDIS_FW.CONF_CENTER.URL", nacos_url.clone());


### PR DESCRIPTION
1. in testcontainer, docker use local addr instead of bridge addr
2. update nacos version to `2.2.3-slim`