### PR TITLE
webserver support grpc

### DIFF
--- a/tardis/Cargo.toml
+++ b/tardis/Cargo.toml
@@ -24,12 +24,7 @@ crypto-with-sm = ["crypto", "libsm", "num-bigint"]
 future = ["futures", "async-stream", "futures-util", "async-trait"]
 tls = ["native-tls"]
 reldb-core = ["future", "sqlparser", "sea-orm", "sqlx"]
-reldb-postgres = [
-    "reldb-core",
-    "sea-orm/postgres-array",
-    "sea-orm/sqlx-postgres",
-    "tardis-macros/reldb-postgres",
-]
+reldb-postgres = ["reldb-core", "sea-orm/postgres-array", "sea-orm/sqlx-postgres", "tardis-macros/reldb-postgres"]
 reldb-mysql = ["reldb-core", "sea-orm/sqlx-mysql", "tardis-macros/reldb-mysql"]
 reldb-sqlite = ["reldb-core", "sea-orm/sqlx-sqlite"]
 reldb = ["reldb-core", "reldb-postgres", "reldb-mysql", "reldb-sqlite"]
@@ -44,6 +39,7 @@ fs = ["tokio/fs"]
 process = ["tokio/process"]
 test = ["testcontainers"]
 tracing = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-otlp"]
+web-server-grpc = ["web-server", "dep:poem-grpc"]
 
 [dependencies]
 # Basic
@@ -128,7 +124,7 @@ poem = { version = "1.3", features = [
     "multipart",
     "tempfile",
 ], optional = true }
-
+poem-grpc = { version = "0.2", optional = true }
 # Web Client
 reqwest = { version = "0.11", features = [
     "json",
@@ -172,6 +168,8 @@ testcontainers = { version = "0.14.0", optional = true }
 tokio = { version = "1", features = ["time", "rt", "macros", "sync"] }
 criterion = { version = "0.5" }
 console-subscriber = "0.1.10"
+poem-grpc-build = "0.2.21"
+prost = "0.11.9"
 
 [[test]]
 name = "test_config"
@@ -199,7 +197,7 @@ required-features = ["test", "reldb"]
 
 [[test]]
 name = "test_web_server"
-required-features = ["test", "web-server", "cache", "web-client", "crypto"]
+required-features = ["test", "web-server", "cache", "web-client", "crypto", "web-server-grpc"]
 
 [[test]]
 name = "test_web_client"

--- a/tardis/src/lib.rs
+++ b/tardis/src/lib.rs
@@ -151,6 +151,8 @@ pub use testcontainers;
 pub use tokio;
 pub use tracing as log;
 pub use url;
+#[cfg(feature = "web-server-grpc")]
+pub use poem_grpc;
 
 use basic::error::TardisErrorWithExt;
 use basic::result::TardisResult;

--- a/tardis/src/lib.rs
+++ b/tardis/src/lib.rs
@@ -137,6 +137,8 @@ pub use futures;
 #[cfg(feature = "future")]
 pub use futures_util;
 pub use lru;
+#[cfg(feature = "web-server-grpc")]
+pub use poem_grpc;
 pub use rand;
 pub use regex;
 pub use serde;
@@ -151,8 +153,6 @@ pub use testcontainers;
 pub use tokio;
 pub use tracing as log;
 pub use url;
-#[cfg(feature = "web-server-grpc")]
-pub use poem_grpc;
 
 use basic::error::TardisErrorWithExt;
 use basic::result::TardisResult;

--- a/tardis/src/lib.rs
+++ b/tardis/src/lib.rs
@@ -1199,6 +1199,7 @@ impl TardisFuns {
             TardisConfig { cs, fw }
         };
 
+        #[allow(unused_variables)]
         let fw_config = TardisFuns::fw_config();
 
         #[cfg(feature = "tracing")]

--- a/tardis/src/web/web_server.rs
+++ b/tardis/src/web/web_server.rs
@@ -179,6 +179,19 @@ impl TardisWebServer {
         self
     }
 
+    #[cfg(feature = "web-server-grpc")]
+    pub async fn add_grpc_module<T, MW, D>(&self, code: &str, module: impl Into<WebServerGrpcModule<T, MW, D>>) -> &Self
+    where
+        T: Clone + Send + Sync + poem::IntoEndpoint<Endpoint = BoxEndpoint<'static, poem::Response>> + poem_grpc::Service + 'static,
+        D: Clone + Send + Sync + 'static,
+        MW: Clone + Send + Sync + Middleware<BoxEndpoint<'static>> + 'static,
+    {
+        let code = code.to_lowercase();
+        let code = code.as_str();
+        self.load_initializer((code.to_string(), module.into())).await;
+        self
+    }
+
     async fn do_add_module_with_data<T, MW, D>(&self, code: &str, module_config: &WebServerModuleConfig, module: WebServerModule<T, MW, D>) -> &Self
     where
         T: OpenApi + 'static,
@@ -223,6 +236,29 @@ impl TardisWebServer {
         } else {
             self.state.lock().await.add_route(code, route.with(cors), data);
         };
+        self
+    }
+
+    #[cfg(feature = "web-server-grpc")]
+    async fn do_add_grpc_module_with_data<T, MW, D>(&self, code: &str, _module_config: &WebServerModuleConfig, module: WebServerGrpcModule<T, MW, D>) -> &Self
+    where
+        T: poem::IntoEndpoint<Endpoint = BoxEndpoint<'static, poem::Response>> + poem_grpc::Service + 'static,
+        D: Clone + Send + Sync + 'static,
+        MW: Middleware<BoxEndpoint<'static>> + 'static,
+    {
+        use poem_grpc::RouteGrpc;
+
+        info!("[Tardis.WebServer] Add grpc module {}", code);
+        let WebServerModule {
+            apis,
+            data,
+            middleware,
+            options: _module_options,
+        } = module.0;
+        let route = RouteGrpc::new().add_service(apis);
+        let route = route.boxed();
+        let route = route.with(middleware);
+        self.state.lock().await.add_route(code, route, data);
         self
     }
 

--- a/tardis/src/web/web_server/module.rs
+++ b/tardis/src/web/web_server/module.rs
@@ -137,3 +137,44 @@ impl Middleware<BoxEndpoint<'static>> for EmptyMiddleWare {
         ep
     }
 }
+
+#[cfg(feature = "web-server-grpc")]
+#[derive(Clone, Default)]
+pub struct WebServerGrpcModule<T, MW = EmptyMiddleWare, D = ()>(pub WebServerModule<T, MW, D>);
+
+#[cfg(feature = "web-server-grpc")]
+impl<T, MW, D> From<WebServerModule<T, MW, D>> for WebServerGrpcModule<T, MW, D> {
+    fn from(value: WebServerModule<T, MW, D>) -> Self {
+        WebServerGrpcModule(value)
+    }
+}
+
+#[cfg(feature = "web-server-grpc")]
+impl<T> From<T> for WebServerGrpcModule<T>
+where
+    T: poem::IntoEndpoint<Endpoint = BoxEndpoint<'static, poem::Response>> + poem_grpc::Service,
+{
+    fn from(apis: T) -> Self {
+        WebServerModule::new(apis).into()
+    }
+}
+
+#[cfg(feature = "web-server-grpc")]
+impl<T, MW> From<(T, MW)> for WebServerGrpcModule<T, MW>
+where
+    MW: Middleware<BoxEndpoint<'static>>,
+{
+    fn from(value: (T, MW)) -> Self {
+        WebServerModule::from(value).into()
+    }
+}
+
+#[cfg(feature = "web-server-grpc")]
+impl<T, MW, D> From<(T, MW, D)> for WebServerGrpcModule<T, MW, D>
+where
+    MW: Middleware<BoxEndpoint<'static>>,
+{
+    fn from(value: (T, MW, D)) -> Self {
+        WebServerModule::from(value).into()
+    }
+}

--- a/tardis/tests/build_proto.rs
+++ b/tardis/tests/build_proto.rs
@@ -1,0 +1,9 @@
+use std::io::Result;
+
+use poem_grpc_build::compile_protos;
+
+fn main() -> Result<()> {
+    std::env::set_var("OUT_DIR", "tests/grpc/rust");
+    compile_protos(&["./tests/grpc/proto/helloworld.proto"], &["./tests/grpc/proto/"])?;
+    Ok(())
+}

--- a/tardis/tests/grpc/proto/helloworld.proto
+++ b/tardis/tests/grpc/proto/helloworld.proto
@@ -1,0 +1,37 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}

--- a/tardis/tests/grpc/rust/helloworld.rs
+++ b/tardis/tests/grpc/rust/helloworld.rs
@@ -1,0 +1,139 @@
+/// The request message containing the user's name.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HelloRequest {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// The response message containing the greetings
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HelloReply {
+    #[prost(string, tag = "1")]
+    pub message: ::prost::alloc::string::String,
+}
+#[allow(unused_imports)]
+#[derive(Clone)]
+pub struct GreeterClient {
+    cli: poem_grpc::client::GrpcClient,
+}
+#[allow(dead_code)]
+impl GreeterClient {
+    #[allow(clippy::let_and_return)]
+    pub fn new(config: poem_grpc::ClientConfig) -> Self {
+        Self {
+            cli: {
+                let cli = poem_grpc::client::GrpcClient::new(config);
+                cli
+            },
+        }
+    }
+    #[allow(clippy::let_and_return)]
+    pub fn from_endpoint<T>(ep: T) -> Self
+    where
+        T: ::poem::IntoEndpoint,
+        T::Endpoint: 'static,
+        <T::Endpoint as ::poem::Endpoint>::Output: 'static,
+    {
+        Self {
+            cli: {
+                let cli = poem_grpc::client::GrpcClient::from_endpoint(ep);
+                cli
+            },
+        }
+    }
+    pub fn with<M>(mut self, middleware: M) -> Self
+    where
+        M: ::poem::Middleware<
+            ::std::sync::Arc<dyn ::poem::Endpoint<Output = ::poem::Response> + 'static>,
+        >,
+        M::Output: 'static,
+    {
+        self.cli = self.cli.with(middleware);
+        self
+    }
+    #[allow(dead_code)]
+    pub async fn say_hello(
+        &self,
+        request: poem_grpc::Request<HelloRequest>,
+    ) -> ::std::result::Result<poem_grpc::Response<HelloReply>, poem_grpc::Status> {
+        let codec = <poem_grpc::codec::ProstCodec<
+            _,
+            _,
+        > as ::std::default::Default>::default();
+        self.cli.unary("/helloworld.Greeter/SayHello", codec, request).await
+    }
+}
+#[allow(unused_imports)]
+#[::poem::async_trait]
+pub trait Greeter: Send + Sync + 'static {
+    async fn say_hello(
+        &self,
+        request: poem_grpc::Request<HelloRequest>,
+    ) -> ::std::result::Result<poem_grpc::Response<HelloReply>, poem_grpc::Status>;
+}
+#[allow(unused_imports)]
+#[derive(Clone)]
+pub struct GreeterServer<T>(::std::sync::Arc<T>);
+impl<T: Greeter> poem_grpc::Service for GreeterServer<T> {
+    const NAME: &'static str = "helloworld.Greeter";
+}
+#[allow(dead_code)]
+impl<T> GreeterServer<T> {
+    pub fn new(service: T) -> Self {
+        Self(::std::sync::Arc::new(service))
+    }
+}
+impl<T: Greeter> ::poem::IntoEndpoint for GreeterServer<T> {
+    type Endpoint = ::poem::endpoint::BoxEndpoint<'static, ::poem::Response>;
+    #[allow(clippy::redundant_clone)]
+    #[allow(clippy::let_and_return)]
+    fn into_endpoint(self) -> Self::Endpoint {
+        use ::poem::endpoint::EndpointExt;
+        let mut route = ::poem::Route::new();
+        #[allow(non_camel_case_types)]
+        struct Greetersay_helloService<T>(::std::sync::Arc<T>);
+        #[::poem::async_trait]
+        impl<T: Greeter> poem_grpc::service::UnaryService<HelloRequest>
+        for Greetersay_helloService<T> {
+            type Response = HelloReply;
+            async fn call(
+                &self,
+                request: poem_grpc::Request<HelloRequest>,
+            ) -> Result<poem_grpc::Response<Self::Response>, poem_grpc::Status> {
+                self.0.say_hello(request).await
+            }
+        }
+        route = route
+            .at(
+                "/SayHello",
+                ::poem::endpoint::make({
+                    let svc = self.0.clone();
+                    move |req| {
+                        let svc = svc.clone();
+                        async move {
+                            let codec = <poem_grpc::codec::ProstCodec<
+                                _,
+                                _,
+                            > as ::std::default::Default>::default();
+                            poem_grpc::server::GrpcServer::new(codec)
+                                .unary(Greetersay_helloService(svc.clone()), req)
+                                .await
+                        }
+                    }
+                }),
+            );
+        let ep = route
+            .before(|req| async move {
+                if req.version() != ::poem::http::Version::HTTP_2 {
+                    return Err(
+                        ::poem::Error::from_status(
+                            ::poem::http::StatusCode::HTTP_VERSION_NOT_SUPPORTED,
+                        ),
+                    );
+                }
+                Ok(req)
+            });
+        ep.boxed()
+    }
+}


### PR DESCRIPTION
# Usage
```rust
#[allow(non_snake_case)]
mod helloworld_grpc {
    include!("./grpc/rust/helloworld.rs");
}
pub use helloworld_grpc::*;
use poem_grpc::{Request as GrpcRequest, Response as GrpcResponse, Status as GrpcStatus};

#[derive(Clone, Default)]
pub struct GreeterGrpcService;
#[poem::async_trait]
impl Greeter for GreeterGrpcService {
    async fn say_hello(&self, request: GrpcRequest<HelloRequest>) -> Result<GrpcResponse<HelloReply>, GrpcStatus> {
        info!("GreeterGrpcService say_hello {:?}", request);
        let reply = HelloReply {
            message: format!("Hello {}!", request.into_inner().name),
        };
        Ok(GrpcResponse::new(reply))
    }
}

// add service
TardisFuns::web_server().add_grpc_module("grpc", GreeterServer::new(GreeterGrpcService))
```