### PR TITLE
crypto using `impl AsRef<[u8]>` as param type if possible

### DIFF
--- a/tardis/src/crypto/crypto_aes.rs
+++ b/tardis/src/crypto/crypto_aes.rs
@@ -17,16 +17,16 @@ pub struct TardisCryptoAes;
 /// let data = TardisFuns::crypto.aes.decrypt_cbc(&encrypted_data, &key, &iv).unwrap();
 /// ```
 impl TardisCryptoAes {
-    pub fn encrypt_ecb(&self, data: &str, hex_key: &str) -> TardisResult<String> {
+    pub fn encrypt_ecb(&self, data: impl AsRef<[u8]>, hex_key: impl AsRef<[u8]>) -> TardisResult<String> {
         self.encrypt(data, hex_key, "", false)
     }
 
-    pub fn encrypt_cbc(&self, data: &str, hex_key: &str, hex_iv: &str) -> TardisResult<String> {
+    pub fn encrypt_cbc(&self, data: impl AsRef<[u8]>, hex_key: impl AsRef<[u8]>, hex_iv: impl AsRef<[u8]>) -> TardisResult<String> {
         self.encrypt(data, hex_key, hex_iv, true)
     }
 
-    fn encrypt(&self, data: &str, hex_key: &str, hex_iv: &str, cbc_mode: bool) -> TardisResult<String> {
-        let key_size = match hex_key.len() {
+    fn encrypt(&self, data: impl AsRef<[u8]>, hex_key: impl AsRef<[u8]>, hex_iv: impl AsRef<[u8]>, cbc_mode: bool) -> TardisResult<String> {
+        let key_size = match hex_key.as_ref().len() {
             16 => crypto::aes::KeySize::KeySize128,
             24 => crypto::aes::KeySize::KeySize192,
             32 => crypto::aes::KeySize::KeySize256,
@@ -39,13 +39,13 @@ impl TardisCryptoAes {
         };
 
         let mut encryptor = if cbc_mode {
-            crypto::aes::cbc_encryptor(key_size, hex_key.as_bytes(), hex_iv.as_bytes(), crypto::blockmodes::PkcsPadding)
+            crypto::aes::cbc_encryptor(key_size, hex_key.as_ref(), hex_iv.as_ref(), crypto::blockmodes::PkcsPadding)
         } else {
-            crypto::aes::ecb_encryptor(key_size, hex_key.as_bytes(), crypto::blockmodes::PkcsPadding)
+            crypto::aes::ecb_encryptor(key_size, hex_key.as_ref(), crypto::blockmodes::PkcsPadding)
         };
 
         let mut final_result = Vec::<u8>::new();
-        let mut read_buffer = crypto::buffer::RefReadBuffer::new(data.as_bytes());
+        let mut read_buffer = crypto::buffer::RefReadBuffer::new(data.as_ref());
         let mut buffer = [0; 4096];
         let mut write_buffer = crypto::buffer::RefWriteBuffer::new(&mut buffer);
 
@@ -60,16 +60,16 @@ impl TardisCryptoAes {
         Ok(hex::encode(final_result))
     }
 
-    pub fn decrypt_ecb(&self, encrypted_data: &str, hex_key: &str) -> TardisResult<String> {
+    pub fn decrypt_ecb(&self, encrypted_data: impl AsRef<[u8]>, hex_key: impl AsRef<[u8]>) -> TardisResult<String> {
         self.decrypt(encrypted_data, hex_key, "", false)
     }
 
-    pub fn decrypt_cbc(&self, encrypted_data: &str, hex_key: &str, hex_iv: &str) -> TardisResult<String> {
+    pub fn decrypt_cbc(&self, encrypted_data: impl AsRef<[u8]>, hex_key: impl AsRef<[u8]>, hex_iv: impl AsRef<[u8]>) -> TardisResult<String> {
         self.decrypt(encrypted_data, hex_key, hex_iv, true)
     }
 
-    fn decrypt(&self, encrypted_data: &str, hex_key: &str, hex_iv: &str, cbc_mode: bool) -> TardisResult<String> {
-        let key_size = match hex_key.len() {
+    fn decrypt(&self, encrypted_data: impl AsRef<[u8]>, hex_key: impl AsRef<[u8]>, hex_iv: impl AsRef<[u8]>, cbc_mode: bool) -> TardisResult<String> {
+        let key_size = match hex_key.as_ref().len() {
             16 => crypto::aes::KeySize::KeySize128,
             24 => crypto::aes::KeySize::KeySize192,
             32 => crypto::aes::KeySize::KeySize256,
@@ -84,9 +84,9 @@ impl TardisCryptoAes {
         let encrypted_data = hex::decode(encrypted_data)?;
 
         let mut decryptor = if cbc_mode {
-            crypto::aes::cbc_decryptor(key_size, hex_key.as_bytes(), hex_iv.as_bytes(), crypto::blockmodes::PkcsPadding)
+            crypto::aes::cbc_decryptor(key_size, hex_key.as_ref(), hex_iv.as_ref(), crypto::blockmodes::PkcsPadding)
         } else {
-            crypto::aes::ecb_decryptor(key_size, hex_key.as_bytes(), crypto::blockmodes::PkcsPadding)
+            crypto::aes::ecb_decryptor(key_size, hex_key.as_ref(), crypto::blockmodes::PkcsPadding)
         };
 
         let mut final_result = Vec::<u8>::new();

--- a/tardis/src/crypto/crypto_base64.rs
+++ b/tardis/src/crypto/crypto_base64.rs
@@ -6,7 +6,7 @@ use crate::basic::result::TardisResult;
 pub struct TardisCryptoBase64;
 
 impl TardisCryptoBase64 {
-    pub fn decode(&self, data: &str) -> TardisResult<String> {
+    pub fn decode(&self, data: impl AsRef<[u8]>) -> TardisResult<String> {
         match general_purpose::STANDARD.decode(data) {
             Ok(result) => Ok(String::from_utf8(result)?),
             Err(error) => Err(TardisError::format_error(
@@ -16,7 +16,7 @@ impl TardisCryptoBase64 {
         }
     }
 
-    pub fn encode(&self, data: &str) -> String {
+    pub fn encode(&self, data: impl AsRef<[u8]>) -> String {
         general_purpose::STANDARD.encode(data)
     }
 

--- a/tardis/src/crypto/crypto_digest.rs
+++ b/tardis/src/crypto/crypto_digest.rs
@@ -22,43 +22,43 @@ pub struct TardisCryptoDigest;
 /// TardisFuns::crypto.digest.sm3("测试").unwrap();
 /// ```
 impl TardisCryptoDigest {
-    pub fn sha1(&self, data: &str) -> TardisResult<String> {
+    pub fn sha1(&self, data: impl AsRef<[u8]>) -> TardisResult<String> {
         self.digest(data, crypto::sha1::Sha1::new())
     }
 
-    pub fn sha256(&self, data: &str) -> TardisResult<String> {
+    pub fn sha256(&self, data: impl AsRef<[u8]>) -> TardisResult<String> {
         self.digest(data, crypto::sha2::Sha256::new())
     }
 
-    pub fn sha512(&self, data: &str) -> TardisResult<String> {
+    pub fn sha512(&self, data: impl AsRef<[u8]>) -> TardisResult<String> {
         self.digest(data, crypto::sha2::Sha512::new())
     }
 
-    pub fn md5(&self, data: &str) -> TardisResult<String> {
+    pub fn md5(&self, data: impl AsRef<[u8]>) -> TardisResult<String> {
         self.digest(data, crypto::md5::Md5::new())
     }
 
-    pub fn hmac_sha1(&self, data: &str, key: &str) -> TardisResult<String> {
+    pub fn hmac_sha1(&self, data: impl AsRef<[u8]>, key: impl AsRef<[u8]>) -> TardisResult<String> {
         self.digest_hmac(data, key, crypto::sha1::Sha1::new())
     }
 
-    pub fn hmac_sha256(&self, data: &str, key: &str) -> TardisResult<String> {
+    pub fn hmac_sha256(&self, data: impl AsRef<[u8]>, key: impl AsRef<[u8]>) -> TardisResult<String> {
         self.digest_hmac(data, key, crypto::sha2::Sha256::new())
     }
 
-    pub fn hmac_sha512(&self, data: &str, key: &str) -> TardisResult<String> {
+    pub fn hmac_sha512(&self, data: impl AsRef<[u8]>, key: impl AsRef<[u8]>) -> TardisResult<String> {
         self.digest_hmac(data, key, crypto::sha2::Sha512::new())
     }
 
     #[cfg(feature = "crypto-with-sm")]
-    pub fn sm3(&self, data: &str) -> TardisResult<String> {
+    pub fn sm3(&self, data: impl AsRef<[u8]>) -> TardisResult<String> {
         use libsm::sm3::hash::Sm3Hash;
 
-        Ok(hex::encode(Sm3Hash::new(data.as_bytes()).get_hash()))
+        Ok(hex::encode(Sm3Hash::new(data.as_ref()).get_hash()))
     }
 
-    pub fn digest<A: crypto::digest::Digest>(&self, data: &str, mut algorithm: A) -> TardisResult<String> {
-        algorithm.input_str(data);
+    pub fn digest<A: crypto::digest::Digest>(&self, data: impl AsRef<[u8]>, mut algorithm: A) -> TardisResult<String> {
+        algorithm.input(data.as_ref());
         Ok(algorithm.result_str())
     }
 
@@ -69,9 +69,9 @@ impl TardisCryptoDigest {
         Ok(buf)
     }
 
-    pub fn digest_hmac<A: crypto::digest::Digest>(&self, data: &str, key: &str, algorithm: A) -> TardisResult<String> {
-        let mut hmac = crypto::hmac::Hmac::new(algorithm, key.as_bytes());
-        hmac.input(data.as_bytes());
+    pub fn digest_hmac<A: crypto::digest::Digest>(&self, data: impl AsRef<[u8]>, key: impl AsRef<[u8]>, algorithm: A) -> TardisResult<String> {
+        let mut hmac = crypto::hmac::Hmac::new(algorithm, key.as_ref());
+        hmac.input(data.as_ref());
         Ok(hex::encode(hmac.result().code()))
     }
 }


### PR DESCRIPTION
Most encrypt algorithems accept `&[u8]` as input parameter, and str also implemented `AsRef<[u8]>`, so it's reasonable to use `impl AsRef<[u8]>` as input parameter type.

```rust
fn some_fn(key: impl AsRef<[u8]>) {

}

some_fn("some str"); // Ok
some_fn([0, 0, 0]); // Ok
some_fn(some_slice); // Ok
```