### PR TITLE
fix: re-export the type `Directive`, deserialize any value into `Void`.

### DIFF
--- a/tardis/src/basic/tracing.rs
+++ b/tardis/src/basic/tracing.rs
@@ -3,10 +3,10 @@ use std::sync::Once;
 use crate::basic::result::TardisResult;
 use crate::config::config_dto::LogConfig;
 
-use crate::TARDIS_INST;
-
 #[allow(unused_imports)]
 use crate::consts::*;
+use crate::TARDIS_INST;
+pub use tracing_subscriber::filter::Directive;
 use tracing_subscriber::layer::Layered;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;

--- a/tardis/src/web/web_resp.rs
+++ b/tardis/src/web/web_resp.rs
@@ -131,5 +131,16 @@ where
     pub records: Vec<T>,
 }
 
-#[derive(Object, Deserialize, Serialize, Clone, Debug, Default, Copy)]
-pub struct Void;
+#[derive(Object, Serialize, Clone, Debug, Default, Copy)]
+/// This `Void` is for represent an empty object `{}`
+/// Any value can be deserialized as `Void`
+pub struct Void {}
+pub const VOID: Void = Void {};
+impl<'de> Deserialize<'de> for Void {
+    fn deserialize<D>(_: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Void {})
+    }
+}

--- a/tardis/src/web/web_resp.rs
+++ b/tardis/src/web/web_resp.rs
@@ -132,15 +132,17 @@ where
 }
 
 #[derive(Object, Serialize, Clone, Debug, Default, Copy)]
-/// This `Void` is for represent an empty object `{}`
-/// Any value can be deserialized as `Void`
-pub struct Void {}
-pub const VOID: Void = Void {};
+/// This `Void` is for represent an empty value.
+/// Any value can be deserialized as `Void`.
+/// Void will be serialized as json's `null`.
+pub struct Void;
 impl<'de> Deserialize<'de> for Void {
-    fn deserialize<D>(_: D) -> Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        Ok(Void {})
+        // ignore this value whatever
+        let _ = deserializer.deserialize_any(serde::de::IgnoredAny)?;
+        Ok(Void)
     }
 }


### PR DESCRIPTION
1. re-export the type `Directive`.
2. `Void` can be deserialized from any json value.