### PR TITLE
Support get git version at built time

### DIFF
--- a/examples/build-info/Cargo.toml
+++ b/examples/build-info/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tardis-example-build-info"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+tardis = { path = "../../tardis", features = ["build-info"] }

--- a/examples/build-info/src/main.rs
+++ b/examples/build-info/src/main.rs
@@ -1,0 +1,6 @@
+pub fn main() {
+    const GIT_VERSION: &str = tardis::utils::build_info::git_version!();
+    const PKG_VERSION: &str = tardis::pkg_version!();
+    const PKG_NAME: &str = tardis::pkg!();
+    println!("{} {} {}", PKG_NAME, PKG_VERSION, GIT_VERSION);
+}

--- a/tardis/Cargo.toml
+++ b/tardis/Cargo.toml
@@ -60,6 +60,7 @@ tokio-console = ["console-subscriber"]
 tracing-appender = ["dep:tracing-appender"]
 web-server-grpc = ["web-server", "dep:poem-grpc"]
 cluster = ["web-server", "ws-client", "cache"]
+build-info = ["git-version"]
 
 [dependencies]
 # Basic
@@ -220,6 +221,9 @@ testcontainers-modules = { version = "0.2", features = [
     "redis",
 ], optional = true }
 
+# Debug
+git-version = {version = "0.3.9", optional = true}
+
 [dev-dependencies]
 # Common
 tokio = { version = "1", features = [
@@ -234,6 +238,8 @@ poem-grpc-build = "0.2.22"
 prost = "0.12"
 strip-ansi-escapes = "0.2.0"
 portpicker = "0.1.1"
+
+
 
 [[test]]
 name = "test_config"

--- a/tardis/README.md
+++ b/tardis/README.md
@@ -53,6 +53,7 @@
 * ``tracing-appender`` write log into file periodically.
 * ``cluster`` work with tardis cluster
 * ``k8s`` k8s support for cluster
+* ``build-info`` get build info like package version or git version
 
 ## 🚀 Quick start
 

--- a/tardis/src/consts.rs
+++ b/tardis/src/consts.rs
@@ -18,3 +18,7 @@ pub const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 
 // shortcuts for build info
 pub const TARDIS_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(feature = "build-info")]
+/// The git version of the tardis crate.
+pub const TARDIS_GIT_VERSION: &str = git_version::git_version!();

--- a/tardis/src/utils.rs
+++ b/tardis/src/utils.rs
@@ -2,7 +2,8 @@ pub mod cached_json_value;
 pub(crate) use cached_json_value::*;
 pub mod tardis_component;
 pub(crate) use tardis_component::*;
+#[cfg(feature = "build-info")]
+pub mod build_info;
 pub mod initializer;
 pub mod mapper;
-pub mod package_name;
 pub mod tardis_static;

--- a/tardis/src/utils/build_info.rs
+++ b/tardis/src/utils/build_info.rs
@@ -1,0 +1,15 @@
+pub use git_version::*;
+
+#[macro_export]
+macro_rules! pkg_version {
+    () => {
+        env!("CARGO_PKG_VERSION")
+    };
+}
+
+#[macro_export]
+macro_rules! pkg {
+    () => {
+        env!("CARGO_PKG_NAME")
+    };
+}

--- a/tardis/src/utils/package_name.rs
+++ b/tardis/src/utils/package_name.rs
@@ -1,6 +1,0 @@
-#[macro_export]
-macro_rules! pkg {
-    () => {
-        env!("CARGO_PKG_NAME")
-    };
-}


### PR DESCRIPTION
example:

```rust
pub fn main() {
    const GIT_VERSION: &str = tardis::utils::build_info::git_version!();
    const PKG_VERSION: &str = tardis::pkg_version!();
    const PKG_NAME: &str = tardis::pkg!();
    println!("{} {} {}", PKG_NAME, PKG_VERSION, GIT_VERSION);
}
```